### PR TITLE
Add Info.plist with required usage descriptions

### DIFF
--- a/Portal.xcodeproj/project.pbxproj
+++ b/Portal.xcodeproj/project.pbxproj
@@ -400,7 +400,8 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Portal/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -432,7 +433,8 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Portal/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Portal/Info.plist
+++ b/Portal/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSAccessibilityUsageDescription</key>
+    <string>Portal needs accessibility access to scan and execute menu commands from applications.</string>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>Portal needs Apple Events access to get file selection from Finder.</string>
+    <key>LSUIElement</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Add NSAccessibilityUsageDescription for menu scanning access
- Add NSAppleEventsUsageDescription for Finder file selection
- Add LSUIElement = true for menu bar app (hide from Dock)
- Update project settings to use custom Info.plist

## Test plan
- [ ] Verify accessibility usage description is present
- [ ] Verify Apple Events usage description is present
- [ ] Verify app is configured as LSUIElement (agent app)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)