### PR TITLE
#78 無効なメニュー項目をリストから除外

### DIFF
--- a/Portal/Testing/MockMenuItemFactory.swift
+++ b/Portal/Testing/MockMenuItemFactory.swift
@@ -22,13 +22,15 @@ enum MockMenuItemFactory {
     private static let mockPrefix = "[Mock] "
 
     /// Creates an array of mock menu items.
-    /// - Parameter count: Number of items to create.
+    /// - Parameters:
+    ///   - count: Number of items to create.
+    ///   - disabledIndices: Set of indices that should be disabled. Defaults to empty (all enabled).
     /// - Returns: Array of MenuItem with sequential titles prefixed with "[Mock] ".
     ///
     /// - Note: All items share the same dummy AXUIElement. These items are suitable
     ///   for UI layout and navigation testing, but not for command execution testing.
     ///   The "[Mock] " prefix makes it immediately obvious these are test items.
-    static func createMockItems(count: Int) -> [MenuItem] {
+    static func createMockItems(count: Int, disabledIndices: Set<Int> = []) -> [MenuItem] {
         let dummyElement = AXUIElementCreateSystemWide()
 
         return (0..<count).map { index in
@@ -38,7 +40,7 @@ enum MockMenuItemFactory {
                 path: ["Mock Menu", title],
                 keyboardShortcut: index < 10 ? "⌘\(index)" : nil,
                 axElement: dummyElement,
-                isEnabled: true
+                isEnabled: !disabledIndices.contains(index)
             )
         }
     }

--- a/Portal/UI/CommandPaletteViewModel.swift
+++ b/Portal/UI/CommandPaletteViewModel.swift
@@ -140,7 +140,7 @@ final class CommandPaletteViewModel: ObservableObject {
                 // Check for cancellation before updating state
                 guard !Task.isCancelled else { return }
 
-                menuItems = items
+                menuItems = items.filter { $0.isEnabled }
                 selectedIndex = 0
             } catch {
                 // Check for cancellation before updating state

--- a/PortalTests/CommandPaletteViewModelTests.swift
+++ b/PortalTests/CommandPaletteViewModelTests.swift
@@ -127,4 +127,34 @@ struct CommandPaletteViewModelTests {
         #expect(viewModel.errorMessage == nil)
         #expect(viewModel.selectedIndex == 1)
     }
+
+    // MARK: - MockMenuItemFactory Tests
+
+    @Test @MainActor
+    func testMockMenuItemFactoryCreatesAllEnabledByDefault() {
+        let items = MockMenuItemFactory.createMockItems(count: 5)
+        #expect(items.count == 5)
+        #expect(items.allSatisfy { $0.isEnabled })
+    }
+
+    @Test @MainActor
+    func testMockMenuItemFactoryCreatesDisabledItems() {
+        let items = MockMenuItemFactory.createMockItems(count: 5, disabledIndices: [1, 3])
+        #expect(items.count == 5)
+        #expect(items[0].isEnabled == true)
+        #expect(items[1].isEnabled == false)
+        #expect(items[2].isEnabled == true)
+        #expect(items[3].isEnabled == false)
+        #expect(items[4].isEnabled == true)
+    }
+
+    @Test @MainActor
+    func testFilteringDisabledItems() {
+        // Simulate what loadMenuItems does: filter disabled items
+        let allItems = MockMenuItemFactory.createMockItems(count: 5, disabledIndices: [1, 3])
+        let filteredItems = allItems.filter { $0.isEnabled }
+
+        #expect(filteredItems.count == 3)
+        #expect(filteredItems.allSatisfy { $0.isEnabled })
+    }
 }


### PR DESCRIPTION
## Summary

- `MenuItem.isEnabled == false`のアイテムをコマンドパレットから除外
- ViewModelでフィルタリング（SOLID原則に従い、表示用データの準備はViewModelの責務）
- MockMenuItemFactoryに`disabledIndices`パラメータを追加

## Review scope

このPRでレビューしてほしいこと:
- フィルタリングロジックの適切性
- テストの網羅性

このPRでレビュー不要なこと:
- なし（シンプルな変更のため）

## Test plan

- [x] 無効なメニュー項目がリストに表示されないことを確認（フィルタリングテスト）
- [x] 有効なメニュー項目が正常に表示されることを確認
- [x] 既存のユニットテストがパスすることを確認

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)