### PR TITLE
#76 Add Ctrl+N/Ctrl+P for list navigation

### DIFF
--- a/Portal/UI/PanelController.swift
+++ b/Portal/UI/PanelController.swift
@@ -18,6 +18,10 @@ final class PanelController: NSObject, NSWindowDelegate {
     private static let enterKeyCode: UInt16 = 76
     /// Comma key for Cmd+, settings shortcut.
     private static let commaKeyCode: UInt16 = 43
+    /// N key for Ctrl+N navigation (Emacs-style).
+    private static let nKeyCode: UInt16 = 45
+    /// P key for Ctrl+P navigation (Emacs-style).
+    private static let pKeyCode: UInt16 = 35
 
     // MARK: - Panel Size Calculation
 
@@ -169,6 +173,18 @@ final class PanelController: NSObject, NSWindowDelegate {
             // reliably when a floating panel has focus.
             if modifiers == .command && event.keyCode == Self.commaKeyCode {
                 NotificationCenter.default.post(name: .openSettings, object: nil)
+                return nil
+            }
+
+            // Handle Ctrl+P for navigating up (Emacs-style)
+            if modifiers == .control && event.keyCode == Self.pKeyCode {
+                NotificationCenter.default.post(name: .navigateUp, object: nil)
+                return nil
+            }
+
+            // Handle Ctrl+N for navigating down (Emacs-style)
+            if modifiers == .control && event.keyCode == Self.nKeyCode {
+                NotificationCenter.default.post(name: .navigateDown, object: nil)
                 return nil
             }
 


### PR DESCRIPTION
## Summary
- Add Emacs-style keybindings (Ctrl+N/Ctrl+P) for list navigation
- Ctrl+N moves selection down (Next)
- Ctrl+P moves selection up (Previous)

## Review scope
このPRでレビューしてほしいこと:
- キーコード定数の値が正しいか
- ハンドリング位置が適切か（Cmd+,の後、userIntentionalModifiersガードの前）

このPRでレビュー不要なこと:
- 既存の矢印キーナビゲーション（変更なし）

## Test plan
- [x] 既存テストがパスすること
- [x] ctrl+nで選択が下に移動する
- [x] ctrl+pで選択が上に移動する
- [x] 既存の矢印キー操作に影響しない

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)