### PR TITLE
#77 初期表示をメニューバー順に変更

### DIFF
--- a/PortalTests/CommandPaletteViewModelTests.swift
+++ b/PortalTests/CommandPaletteViewModelTests.swift
@@ -157,4 +157,19 @@ struct CommandPaletteViewModelTests {
         #expect(filteredItems.count == 3)
         #expect(filteredItems.allSatisfy { $0.isEnabled })
     }
+
+    // MARK: - Results Order Tests
+
+    @Test @MainActor
+    func testResultsPreservesMenuItemsOrderWhenSearchTextIsEmpty() {
+        let viewModel = CommandPaletteViewModel()
+        let items = MockMenuItemFactory.createMockItems(count: 5)
+        viewModel.menuItems = items
+
+        #expect(viewModel.searchText.isEmpty)
+        #expect(viewModel.results.count == items.count)
+        for (index, item) in viewModel.results.enumerated() {
+            #expect(item.title == items[index].title)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- 初期表示（検索クエリが空）で `menuItems` の順序が保持されることを確認するテストを追加

## 調査結果

現在の実装を分析した結果、すでに期待通りの動作をしていることが判明：

```swift
var results: [MenuItem] {
    if searchText.isEmpty {
        return menuItems  // メニューバー順（MenuCrawlerの返却順）
    }
    return filteredResults.map(\.item)  // FuzzySearchによるスコア順
}
```

Issue の説明「検索クエリが空でもFuzzySearchを通す」は現在のコードと矛盾しており、過去のバージョンで発生していた問題が既に修正されていた可能性があります。

## Review scope

このPRでレビューしてほしいこと:
- テストが期待動作を正しく検証しているか

このPRでレビュー不要なこと:
- コード変更は新規テストのみのため、機能実装のレビューは不要

## Test plan

- [x] 新規テスト `testResultsPreservesMenuItemsOrderWhenSearchTextIsEmpty` がパスする
- [x] 既存の全ユニットテストがパスする

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)