### PR TITLE
#68 アクティブなアプリがないときOption+Spaceを無視する

### DIFF
--- a/Portal/App/AppDelegate.swift
+++ b/Portal/App/AppDelegate.swift
@@ -173,6 +173,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             } else {
                 targetApp = nil
             }
+
+            // Ignore hotkey when no active app (targetApp is nil)
+            // This prevents showing the panel when MenuCrawler cannot fetch menus
+            guard targetApp != nil else { return }
+
             panelController.toggle(targetApp: targetApp)
         } else {
             let shouldPrompt: Bool


### PR DESCRIPTION
## Summary
- アクティブなアプリがない場合、Option+Spaceを押してもパネルを表示しない
- `handleHotkeyPressed()`で`targetApp`がnilの場合は早期リターン

## Review scope
このPRでレビューしてほしいこと:
- 早期リターンの実装が適切か
- コメントが明確か

このPRでレビュー不要なこと:
- 特になし

## Test plan
- [ ] ビルドが通ること (✅ 確認済み)
- [ ] 既存テストがパスすること (✅ 確認済み)
- [ ] 手動テスト: Finderがアクティブな状態でOption+Space → パネル表示される
- [ ] 手動テスト: アクティブなアプリがない状態でOption+Space → パネル表示されない

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)