### PR TITLE
#104 Vimiumライクなヒントモードの実装

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -1,0 +1,145 @@
+# コード品質
+
+PRを作成する前に確認すべき品質チェックリスト。
+
+## 命名の一貫性
+
+**機能を拡張したら、名前も更新する。**
+
+```swift
+// NG: メニューとサイドバー両方を扱うのに「menu」という名前
+func loadMenuItems() { ... }
+var menuItemsResult = ...
+
+// OK: 実際の機能を反映した名前
+func loadItems() { ... }
+var crawledMenuItems = ...
+```
+
+| 変更内容 | 確認事項 |
+|---------|---------|
+| 機能拡張 | メソッド名、変数名、パラメータ名が新しい機能を反映しているか |
+| 型の追加 | 関連するドキュメントコメントが一般化されているか |
+
+## コードの一貫性
+
+**同様の処理は同じパターンで実装する。**
+
+```swift
+// NG: メニュー走査では nil 処理があるが、サイドバー走査では省略
+if app == nil {
+    menuItems = menuCrawler.crawlActiveApplication()  // nil処理あり
+}
+// サイドバーはappがnilの場合スキップ... ← 一貫性がない
+
+// OK: 両方とも同じパターンで処理
+if app == nil {
+    menuItems = menuCrawler.crawlActiveApplication()
+    sidebarItems = windowCrawler.crawlActiveApplication()
+}
+```
+
+**確認方法:**
+1. 類似の既存コードを検索する
+2. edge case（nil、空配列、エラー）の処理を比較する
+3. 異なる場合は意図的かどうか確認する
+
+## ドキュメントの追従
+
+**コードを変更したら、関連ドキュメントも更新する。**
+
+```swift
+// NG: MenuCrawler固有の説明だが、WindowCrawlerも同様の動作をする
+/// The short cache duration (0.5s) in `MenuCrawler` helps mitigate...
+
+// OK: 一般化した説明
+/// Crawlers may cache results briefly to improve performance...
+```
+
+| 変更内容 | 更新対象 |
+|---------|---------|
+| 新しいサービス追加 | CLAUDE.md のアーキテクチャセクション |
+| 機能拡張 | 関連するドキュメントコメント |
+| 新しいテスト追加 | CLAUDE.md のテストセクション |
+
+## 意図的な動作の明示
+
+**バグに見える可能性のある意図的な動作にはコメントを追加する。**
+
+```swift
+// NG: 親要素と子要素の両方を追加しているが、重複ではないか疑問が残る
+if sidebarItemRoles.contains(role) {
+    items.append(item)
+}
+if hasChildren(element) {
+    items.append(contentsOf: crawlChildren(element))
+}
+
+// OK: 意図を明示
+// Note: Intentionally process both the item and its children.
+// Expandable sidebar rows (e.g., collapsible folders) are themselves
+// actionable AND contain independent child items. Each has a unique
+// path, so no duplicates occur.
+if sidebarItemRoles.contains(role) {
+    items.append(item)
+}
+if hasChildren(element) {
+    items.append(contentsOf: crawlChildren(element))
+}
+```
+
+## 未使用コードの削除
+
+**YAGNI原則: 「今必要ないものは作らない」**
+
+```swift
+// NG: 将来使うかもしれないヘルパーメソッド
+private func getIdentifier(_ element: AXUIElement) -> String? { ... }  // 未使用
+private func getActions(_ element: AXUIElement) -> [String] { ... }    // 未使用
+
+// OK: 使用されているメソッドのみ残す
+// 必要になった時点で追加する
+```
+
+**PR作成前のチェック:**
+- 追加したヘルパーメソッドがすべて使用されているか確認
+- 未使用のメソッドは削除（必要になったら再追加）
+
+## 重複コードの抽出
+
+**同じロジックが複数箇所に存在する場合は共通化を検討する。**
+
+```swift
+// NG: WindowCrawler と CommandExecutor で同じロジック
+// WindowCrawler.swift
+private func getTitleFromRowChildren(_ element: AXUIElement) -> String? {
+    // 50行のロジック...
+}
+
+// CommandExecutor.swift
+private func getTitleFromChildren(_ element: AXUIElement) -> String? {
+    // 同じ50行のロジック...
+}
+
+// OK: 共通ユーティリティに抽出
+// AccessibilityHelper.swift
+enum AccessibilityHelper {
+    static func getTitleFromChildren(_ element: AXUIElement) -> String? {
+        // 共通ロジック
+    }
+}
+```
+
+**判断基準:**
+- 3行以上の同一ロジックが2箇所以上 → 抽出を検討
+- 将来的に変更が必要になりそうな箇所 → 抽出を検討
+- 現在のPRスコープ外の場合 → Issueを作成して追跡
+
+## PR作成前チェックリスト
+
+- [ ] 新しいメソッド/変数の名前が実際の機能を反映しているか
+- [ ] 類似の既存コードと同じパターンで実装しているか
+- [ ] 関連するドキュメントコメントを更新したか
+- [ ] 意図的だが紛らわしい動作にコメントを追加したか
+- [ ] 未使用のコードを削除したか
+- [ ] 重複コードがないか確認したか（ある場合はIssue作成）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,16 @@ Portal/
 ├── Models/
 │   ├── MenuItem.swift         # コマンド項目のデータモデル（メニュー/ウィンドウ）
 │   └── CommandExecutionError.swift # 実行エラー型
+├── HintMode/
+│   ├── HintLabel.swift            # ヒントラベルのデータモデル
+│   ├── HintLabelGenerator.swift   # A-Z, AA-AZ式ラベル生成
+│   ├── HintOverlayView.swift      # SwiftUIラベル描画
+│   ├── HintOverlayWindow.swift    # オーバーレイウィンドウ管理
+│   └── HintModeController.swift   # ヒントモード全体制御
 ├── Services/
 │   ├── HotkeyManager.swift    # 設定可能なホットキー検出
 │   ├── AccessibilityService.swift  # 権限チェック・リクエスト
+│   ├── AccessibilityHelper.swift   # 位置情報取得ユーティリティ
 │   ├── MenuCrawler.swift      # メニューバー走査サービス
 │   ├── WindowCrawler.swift    # ウィンドウ要素走査サービス（サイドバー/ツールバー/コンテンツ）
 │   ├── FuzzySearch.swift      # スコアベース曖昧検索
@@ -113,6 +120,15 @@ Portal/
 - [x] タイプ別アイコン表示（#84）
 - [x] タイプ別フィルタ（Cmd+1/2）（#89, #101）
 
+### ヒントモード（Vimiumライク）
+- [x] 単独Fキーでヒントモード起動（#104）
+- [x] `WindowCrawler`で操作可能要素取得（#104）
+- [x] `kAXPositionAttribute`/`kAXSizeAttribute`で位置取得（#104）
+- [x] A-Z, AA-AZ式ラベル生成（#104）
+- [x] オーバーレイウィンドウでラベル表示（#104）
+- [x] キー入力で要素選択・実行（#104）
+- [x] ESCで終了、Backspaceで入力クリア（#104）
+
 ## パフォーマンス目標
 
 | 指標 | 目標 |
@@ -137,6 +153,7 @@ PortalTests/
 ├── PortalTests.swift                    # テンプレート
 ├── CommandPaletteViewModelTests.swift   # ViewModelテスト
 ├── FuzzySearchTests.swift               # 検索アルゴリズムテスト
+├── HintLabelGeneratorTests.swift        # ヒントラベル生成テスト
 ├── HotkeyConfigurationTests.swift       # ホットキー設定テスト
 └── MenuItemTests.swift                  # MenuItemテスト
 

--- a/Portal/App/Notifications.swift
+++ b/Portal/App/Notifications.swift
@@ -35,6 +35,12 @@ extension Notification.Name {
 
     /// Posted when user presses Cmd+2 to toggle window items filter.
     static let toggleWindowFilter = Notification.Name("com.matsuokashuhei.Portal.toggleWindowFilter")
+
+    /// Posted when hint mode is activated.
+    static let hintModeDidActivate = Notification.Name("com.matsuokashuhei.Portal.hintModeDidActivate")
+
+    /// Posted when hint mode is deactivated.
+    static let hintModeDidDeactivate = Notification.Name("com.matsuokashuhei.Portal.hintModeDidDeactivate")
 }
 
 /// Keys for notification userInfo dictionaries.

--- a/Portal/HintMode/HintLabel.swift
+++ b/Portal/HintMode/HintLabel.swift
@@ -1,0 +1,56 @@
+//
+//  HintLabel.swift
+//  Portal
+//
+//  Created by Claude Code on 2026/01/03.
+//
+
+import CoreGraphics
+import Foundation
+
+/// Represents a hint label displayed on the overlay for keyboard navigation.
+///
+/// Each `HintLabel` corresponds to an interactive UI element in the target application.
+/// The user types the label characters to select and execute the corresponding element.
+struct HintLabel: Identifiable {
+    /// Unique identifier (same as `label`).
+    var id: String { label }
+
+    /// Display label for keyboard navigation (e.g., "A", "AB", "ZZ").
+    let label: String
+
+    /// Screen coordinates where the label should be displayed.
+    /// This is in AppKit coordinate system (origin at bottom-left).
+    let frame: CGRect
+
+    /// The menu item associated with this hint.
+    /// Contains the `axElement` reference for command execution.
+    let menuItem: MenuItem
+
+    /// Center point of the frame for label positioning.
+    var centerPoint: CGPoint {
+        CGPoint(x: frame.midX, y: frame.midY)
+    }
+
+    /// Top-left corner position for label display.
+    /// Labels are typically displayed at the top-left of the element.
+    var displayPosition: CGPoint {
+        CGPoint(x: frame.minX, y: frame.maxY)
+    }
+}
+
+// MARK: - Equatable
+
+extension HintLabel: Equatable {
+    static func == (lhs: HintLabel, rhs: HintLabel) -> Bool {
+        lhs.label == rhs.label
+    }
+}
+
+// MARK: - Hashable
+
+extension HintLabel: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(label)
+    }
+}

--- a/Portal/HintMode/HintModeController.swift
+++ b/Portal/HintMode/HintModeController.swift
@@ -1,0 +1,468 @@
+//
+//  HintModeController.swift
+//  Portal
+//
+//  Created by Claude Code on 2026/01/03.
+//
+
+import AppKit
+import ApplicationServices
+import CoreGraphics
+
+// MARK: - CGEvent Extension
+
+extension CGEvent {
+    /// Gets the characters from a keyboard event, ignoring modifiers.
+    func keyboardEventCharactersIgnoringModifiers() -> String? {
+        var length = 0
+        keyboardGetUnicodeString(maxStringLength: 0, actualStringLength: &length, unicodeString: nil)
+
+        guard length > 0 else { return nil }
+
+        var chars = [UniChar](repeating: 0, count: length)
+        keyboardGetUnicodeString(maxStringLength: length, actualStringLength: &length, unicodeString: &chars)
+
+        return String(utf16CodeUnits: chars, count: length)
+    }
+}
+
+/// Controls the hint mode for keyboard navigation of UI elements.
+///
+/// The controller manages the lifecycle of hint mode, including:
+/// - Crawling window elements from the target application
+/// - Generating and displaying hint labels
+/// - Processing keyboard input for element selection
+/// - Executing the selected element
+@MainActor
+final class HintModeController {
+    // MARK: - Singleton
+
+    /// The shared instance of the hint mode controller.
+    static let shared = HintModeController()
+
+    // MARK: - State
+
+    /// Whether hint mode is currently active.
+    private(set) var isActive: Bool = false
+
+    /// The overlay windows displaying hint labels.
+    private var overlayWindows: [HintOverlayWindow] = []
+
+    /// All hint labels being displayed.
+    private var hints: [HintLabel] = []
+
+    /// The current input buffer for label matching.
+    private var inputBuffer: String = ""
+
+    /// The target application being navigated.
+    private var targetApp: NSRunningApplication?
+
+    /// The CGEventTap for consuming keyboard events during hint mode.
+    /// Using nonisolated(unsafe) because this is accessed from the event tap callback
+    /// which runs on a different thread, but is only modified on MainActor.
+    nonisolated(unsafe) private var eventTap: CFMachPort?
+
+    /// The run loop source for the event tap.
+    private var runLoopSource: CFRunLoopSource?
+
+    /// Fallback keyboard monitor when CGEventTap is not available.
+    private var keyboardMonitor: Any?
+
+    // MARK: - Dependencies
+
+    /// The window crawler for retrieving UI elements.
+    private let windowCrawler = WindowCrawler()
+
+    /// The command executor for performing actions.
+    private let commandExecutor = CommandExecutor()
+
+    // MARK: - Initialization
+
+    private init() {}
+
+    // MARK: - Public Methods
+
+    /// Activates hint mode for the specified application.
+    ///
+    /// - Parameter app: The application to navigate. If nil, uses the frontmost application.
+    func activate(for app: NSRunningApplication? = nil) {
+        guard !isActive else {
+            #if DEBUG
+            print("[HintModeController] Already active")
+            #endif
+            return
+        }
+
+        // Get target application (excluding Portal itself)
+        targetApp = app ?? getFrontmostApp()
+        guard let targetApp else {
+            #if DEBUG
+            print("[HintModeController] No target application")
+            #endif
+            return
+        }
+
+        #if DEBUG
+        print("[HintModeController] Activating for \(targetApp.localizedName ?? "unknown")")
+        #endif
+
+        // Start the activation process
+        Task {
+            await performActivation(for: targetApp)
+        }
+    }
+
+    /// Deactivates hint mode and dismisses the overlay.
+    func deactivate() {
+        guard isActive else { return }
+
+        #if DEBUG
+        print("[HintModeController] Deactivating")
+        #endif
+
+        // Stop keyboard monitoring
+        stopKeyboardMonitor()
+
+        // Dismiss overlay windows
+        #if DEBUG
+        print("[HintModeController] Dismissing \(overlayWindows.count) overlay windows")
+        #endif
+        for window in overlayWindows {
+            window.dismiss()
+        }
+        overlayWindows.removeAll()
+        #if DEBUG
+        print("[HintModeController] Overlay windows cleared")
+        #endif
+
+        // Reset state
+        hints.removeAll()
+        inputBuffer = ""
+        targetApp = nil
+        isActive = false
+
+        // Post notification
+        NotificationCenter.default.post(name: .hintModeDidDeactivate, object: nil)
+    }
+
+    // MARK: - Private Methods
+
+    /// Performs the async activation process.
+    private func performActivation(for app: NSRunningApplication) async {
+        do {
+            // Crawl window elements
+            let crawlResult = try await windowCrawler.crawlWindowElements(app)
+            var items = crawlResult.items
+
+            guard !items.isEmpty else {
+                #if DEBUG
+                print("[HintModeController] No window elements found")
+                #endif
+                return
+            }
+
+            #if DEBUG
+            print("[HintModeController] Crawled \(items.count) items (isPopupMenu: \(crawlResult.isPopupMenu))")
+            #endif
+
+            // Filter items by window bounds ONLY for normal window crawling
+            // Skip filtering for popup menus since they can extend beyond window bounds
+            if !crawlResult.isPopupMenu {
+                // Get all window frames for filtering (includes main window, popups, dialogs)
+                let windowFrames = AccessibilityHelper.getAllWindowFrames(app)
+                #if DEBUG
+                print("[HintModeController] Found \(windowFrames.count) window frames")
+                for (index, frame) in windowFrames.enumerated() {
+                    print("[HintModeController] Window \(index): \(frame.debugDescription)")
+                }
+                #endif
+
+                if !windowFrames.isEmpty {
+                    items = items.filter { item in
+                        guard let frame = AccessibilityHelper.getFrame(item.axElement) else {
+                            return false
+                        }
+                        // Check if element is within ANY of the window bounds
+                        let isInAnyWindow = windowFrames.contains { windowFrame in
+                            windowFrame.contains(frame) || windowFrame.intersects(frame)
+                        }
+                        guard isInAnyWindow else {
+                            return false
+                        }
+                        // Check visibility in scroll containers (filters out scrolled-out elements)
+                        return AccessibilityHelper.isVisibleInScrollContainers(item.axElement)
+                    }
+                    #if DEBUG
+                    print("[HintModeController] Filtered to \(items.count) items within window bounds and visible in scroll containers")
+                    #endif
+                }
+
+                guard !items.isEmpty else {
+                    #if DEBUG
+                    print("[HintModeController] No items within window bounds")
+                    #endif
+                    return
+                }
+            }
+
+            // Get frames for filtered elements
+            let frames = items.map { AccessibilityHelper.getFrame($0.axElement) ?? .zero }
+
+            // Create hint labels for filtered items only
+            hints = HintLabelGenerator.createHintLabels(from: items, frames: frames)
+
+            guard !hints.isEmpty else {
+                #if DEBUG
+                print("[HintModeController] No valid hints (all frames invalid)")
+                #endif
+                return
+            }
+
+            #if DEBUG
+            print("[HintModeController] Created \(hints.count) hints")
+            #endif
+
+            // Create and show overlay windows
+            guard let screen = NSScreen.main else { return }
+            let overlayWindow = HintOverlayWindow(hints: hints, on: screen)
+            overlayWindow.show()
+            overlayWindows = [overlayWindow]
+
+            // Start keyboard monitoring
+            startKeyboardMonitor()
+
+            isActive = true
+
+            // Post notification
+            NotificationCenter.default.post(name: .hintModeDidActivate, object: nil)
+
+        } catch {
+            #if DEBUG
+            print("[HintModeController] Activation failed: \(error)")
+            #endif
+        }
+    }
+
+    /// Gets the frontmost application excluding Portal.
+    private func getFrontmostApp() -> NSRunningApplication? {
+        guard let frontmost = NSWorkspace.shared.frontmostApplication,
+              frontmost.bundleIdentifier != Bundle.main.bundleIdentifier else {
+            return nil
+        }
+        return frontmost
+    }
+
+    // MARK: - Keyboard Handling
+
+    /// Starts monitoring keyboard events using CGEventTap.
+    ///
+    /// CGEventTap is used instead of `addGlobalMonitorForEvents` because:
+    /// - Global monitors only observe events, they cannot consume them
+    /// - This causes key events to reach the target app (e.g., pressing "B" selects Bluetooth in System Settings)
+    /// - CGEventTap can intercept and consume events by returning nil from the callback
+    private func startKeyboardMonitor() {
+        let eventMask = (1 << CGEventType.keyDown.rawValue)
+
+        // Pass self as userInfo to access in the callback
+        let userInfo = Unmanaged.passUnretained(self).toOpaque()
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: CGEventMask(eventMask),
+            callback: { _, type, event, userInfo -> Unmanaged<CGEvent>? in
+                guard let userInfo else {
+                    return Unmanaged.passRetained(event)
+                }
+
+                // Handle tap disabled event (system may disable the tap)
+                if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+                    // Re-enable the tap if it was disabled
+                    let controller = Unmanaged<HintModeController>.fromOpaque(userInfo).takeUnretainedValue()
+                    if let tap = controller.eventTap {
+                        CGEvent.tapEnable(tap: tap, enable: true)
+                    }
+                    return Unmanaged.passRetained(event)
+                }
+
+                // Get the controller from userInfo
+                let controller = Unmanaged<HintModeController>.fromOpaque(userInfo).takeUnretainedValue()
+
+                // Process the key event on MainActor
+                // Note: We process synchronously here to determine whether to consume the event
+                let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+                let characters = event.keyboardEventCharactersIgnoringModifiers()
+
+                // Dispatch to MainActor for state updates
+                Task { @MainActor in
+                    controller.handleKeyEvent(keyCode: keyCode, characters: characters)
+                }
+
+                // Consume the event (return nil) to prevent it from reaching the target app
+                // ESC (53), Backspace (51), and letter keys are all consumed during hint mode
+                let shouldConsume = keyCode == 53 || keyCode == 51 || (characters?.first?.isLetter == true)
+                if shouldConsume {
+                    return nil
+                }
+
+                // Pass through other events
+                return Unmanaged.passRetained(event)
+            },
+            userInfo: userInfo
+        ) else {
+            #if DEBUG
+            print("[HintModeController] Failed to create CGEventTap, falling back to global monitor")
+            #endif
+            // Fallback to global monitor (events won't be consumed)
+            keyboardMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                Task { @MainActor in
+                    self?.handleKeyDown(event)
+                }
+            }
+            return
+        }
+
+        eventTap = tap
+        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        if let source = runLoopSource {
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+        CGEvent.tapEnable(tap: tap, enable: true)
+
+        #if DEBUG
+        print("[HintModeController] CGEventTap started successfully")
+        #endif
+    }
+
+    /// Stops monitoring keyboard events.
+    private func stopKeyboardMonitor() {
+        // Stop CGEventTap
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            eventTap = nil
+        }
+        if let source = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+            runLoopSource = nil
+        }
+
+        // Stop fallback monitor if used
+        if let monitor = keyboardMonitor {
+            NSEvent.removeMonitor(monitor)
+            keyboardMonitor = nil
+        }
+
+        #if DEBUG
+        print("[HintModeController] Keyboard monitor stopped")
+        #endif
+    }
+
+    /// Handles a key down event from NSEvent (fallback monitor).
+    ///
+    /// - Parameter event: The key event.
+    private func handleKeyDown(_ event: NSEvent) {
+        handleKeyEvent(keyCode: Int64(event.keyCode), characters: event.charactersIgnoringModifiers)
+    }
+
+    /// Handles a key event from CGEventTap or NSEvent.
+    ///
+    /// - Parameters:
+    ///   - keyCode: The key code of the pressed key.
+    ///   - characters: The characters generated by the key press (ignoring modifiers).
+    private func handleKeyEvent(keyCode: Int64, characters: String?) {
+        // ESC - deactivate
+        if keyCode == 53 {
+            deactivate()
+            return
+        }
+
+        // Backspace - clear input
+        if keyCode == 51 {
+            if !inputBuffer.isEmpty {
+                inputBuffer.removeLast()
+                updateOverlay()
+            }
+            return
+        }
+
+        // Letter keys (A-Z)
+        guard let characters = characters?.uppercased(),
+              characters.count == 1,
+              let char = characters.first,
+              char.isLetter else {
+            return
+        }
+
+        // Add to input buffer
+        inputBuffer.append(char)
+
+        // Check for match
+        processInput()
+    }
+
+    /// Processes the current input to find matches.
+    ///
+    /// Uses Vimium-style matching: only executes when the input uniquely identifies
+    /// a single hint. This allows multi-character labels (e.g., "AA") to be typed
+    /// even when single-character labels (e.g., "A") exist.
+    private func processInput() {
+        // Filter hints that match the current input
+        let filtered = HintLabelGenerator.filterHints(hints, by: inputBuffer)
+
+        // No matches - reset input
+        if filtered.isEmpty {
+            #if DEBUG
+            print("[HintModeController] No matches for '\(inputBuffer)', resetting")
+            #endif
+            inputBuffer = ""
+            updateOverlay()
+            return
+        }
+
+        // Exactly one match - execute
+        if filtered.count == 1 {
+            executeHint(filtered[0])
+            return
+        }
+
+        // Multiple matches - update overlay and wait for more input
+        #if DEBUG
+        print("[HintModeController] Multiple matches (\(filtered.count)) for '\(inputBuffer)', waiting for more input")
+        #endif
+        updateOverlay()
+    }
+
+    /// Updates the overlay windows with the current input.
+    private func updateOverlay() {
+        for window in overlayWindows {
+            window.updateVisibleHints(for: inputBuffer)
+        }
+    }
+
+    /// Executes the action for the selected hint.
+    ///
+    /// - Parameter hint: The hint to execute.
+    private func executeHint(_ hint: HintLabel) {
+        #if DEBUG
+        print("[HintModeController] Executing hint '\(hint.label)' for '\(hint.menuItem.title)'")
+        #endif
+
+        // Execute the command
+        let result = commandExecutor.execute(hint.menuItem)
+
+        switch result {
+        case .success:
+            #if DEBUG
+            print("[HintModeController] Execution successful")
+            #endif
+        case .failure(let error):
+            #if DEBUG
+            print("[HintModeController] Execution failed: \(error)")
+            #endif
+        }
+
+        // Deactivate after execution (success or failure)
+        deactivate()
+    }
+}

--- a/Portal/HintMode/HintOverlayView.swift
+++ b/Portal/HintMode/HintOverlayView.swift
@@ -1,0 +1,153 @@
+//
+//  HintOverlayView.swift
+//  Portal
+//
+//  Created by Claude Code on 2026/01/03.
+//
+
+import SwiftUI
+
+/// The main overlay view that displays hint labels at element positions.
+///
+/// This view is displayed fullscreen over the target application and shows
+/// keyboard navigation hints at the position of each interactive element.
+struct HintOverlayView: View {
+    /// All hint labels to potentially display.
+    let hints: [HintLabel]
+
+    /// The user's current input for filtering hints.
+    let currentInput: String
+
+    /// The screen bounds for coordinate conversion.
+    let screenBounds: CGRect
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                // Semi-transparent overlay (optional, can be removed for pure transparency)
+                Color.black.opacity(0.01)
+                    .allowsHitTesting(false)
+
+                // Hint labels positioned at element locations
+                ForEach(filteredHints) { hint in
+                    HintLabelView(hint: hint, input: currentInput)
+                        .position(
+                            x: hint.frame.minX + 10,
+                            y: geometry.size.height - hint.frame.maxY + 10
+                        )
+                }
+            }
+        }
+    }
+
+    /// Hints filtered by the current user input.
+    private var filteredHints: [HintLabel] {
+        HintLabelGenerator.filterHints(hints, by: currentInput)
+    }
+}
+
+/// A single hint label badge displayed at an element's position.
+struct HintLabelView: View {
+    let hint: HintLabel
+    let input: String
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // Matched portion (dimmed)
+            if !input.isEmpty {
+                Text(matchedPortion)
+                    .foregroundColor(.white.opacity(0.6))
+            }
+
+            // Remaining portion (bright)
+            Text(remainingPortion)
+                .foregroundColor(.white)
+        }
+        .font(.system(size: 11, weight: .bold, design: .monospaced))
+        .padding(.horizontal, 4)
+        .padding(.vertical, 2)
+        .background(
+            RoundedRectangle(cornerRadius: 3)
+                .fill(Color.orange)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 3)
+                .stroke(Color.black.opacity(0.3), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 1)
+    }
+
+    /// The portion of the label that matches the current input.
+    private var matchedPortion: String {
+        guard !input.isEmpty else { return "" }
+        let inputLength = min(input.count, hint.label.count)
+        return String(hint.label.prefix(inputLength))
+    }
+
+    /// The portion of the label that hasn't been matched yet.
+    private var remainingPortion: String {
+        guard !input.isEmpty else { return hint.label }
+        let inputLength = min(input.count, hint.label.count)
+        return String(hint.label.dropFirst(inputLength))
+    }
+}
+
+/// View showing the current input buffer at the bottom of the screen.
+struct InputBufferView: View {
+    let input: String
+
+    var body: some View {
+        if !input.isEmpty {
+            HStack {
+                Text("Input:")
+                    .foregroundColor(.secondary)
+                Text(input)
+                    .font(.system(.body, design: .monospaced))
+                    .fontWeight(.bold)
+                    .foregroundColor(.primary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color(.windowBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+            )
+            .shadow(radius: 4)
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Hint Label") {
+    HintLabelView(
+        hint: HintLabel(
+            label: "AB",
+            frame: CGRect(x: 100, y: 100, width: 80, height: 24),
+            menuItem: MenuItem(
+                title: "Test",
+                path: ["Test"],
+                keyboardShortcut: nil,
+                axElement: AXUIElementCreateSystemWide(),
+                isEnabled: true,
+                type: .window
+            )
+        ),
+        input: "A"
+    )
+    .padding()
+    .background(Color.gray)
+}
+
+#Preview("Input Buffer") {
+    VStack(spacing: 20) {
+        InputBufferView(input: "")
+        InputBufferView(input: "A")
+        InputBufferView(input: "AB")
+    }
+    .padding()
+}

--- a/Portal/HintMode/HintOverlayWindow.swift
+++ b/Portal/HintMode/HintOverlayWindow.swift
@@ -1,0 +1,148 @@
+//
+//  HintOverlayWindow.swift
+//  Portal
+//
+//  Created by Claude Code on 2026/01/03.
+//
+
+import AppKit
+import SwiftUI
+
+/// A transparent overlay window that displays hint labels over the target application.
+///
+/// This window covers the entire screen and shows hint labels at the positions
+/// of interactive UI elements. It passes through mouse events and only captures
+/// keyboard input for hint selection.
+final class HintOverlayWindow: NSWindow {
+    /// The hint labels being displayed.
+    private var hints: [HintLabel]
+
+    /// The current user input for filtering hints.
+    private var currentInput: String = ""
+
+    /// The hosting view for SwiftUI content.
+    private var hostingView: NSHostingView<HintOverlayView>?
+
+    /// Creates an overlay window for displaying hint labels.
+    ///
+    /// - Parameters:
+    ///   - hints: The hint labels to display.
+    ///   - screen: The screen to display the overlay on.
+    init(hints: [HintLabel], on screen: NSScreen) {
+        self.hints = hints
+
+        super.init(
+            contentRect: screen.frame,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+
+        setupWindow()
+        setupContent(screen: screen)
+    }
+
+    /// Configures the window properties for overlay display.
+    private func setupWindow() {
+        // Window level above popup menus and floating windows
+        // Use popUpMenu level + 1 to ensure hints appear above context menus
+        level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.popUpMenuWindow)) + 1)
+
+        // Transparent background
+        backgroundColor = .clear
+        isOpaque = false
+        hasShadow = false
+
+        // Pass through mouse events
+        ignoresMouseEvents = true
+
+        // Appear on all spaces and work with fullscreen apps
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+
+        // Don't show in Dock or Mission Control
+        isExcludedFromWindowsMenu = true
+
+        // Prevent automatic release when closed to avoid dangling references
+        isReleasedWhenClosed = false
+    }
+
+    deinit {
+        #if DEBUG
+        print("[HintOverlayWindow] deinit")
+        #endif
+    }
+
+    /// Sets up the SwiftUI content view.
+    private func setupContent(screen: NSScreen) {
+        let overlayView = HintOverlayView(
+            hints: hints,
+            currentInput: currentInput,
+            screenBounds: screen.frame
+        )
+
+        hostingView = NSHostingView(rootView: overlayView)
+        contentView = hostingView
+    }
+
+    /// Updates the visible hints based on user input.
+    ///
+    /// - Parameter input: The current user input string.
+    func updateVisibleHints(for input: String) {
+        currentInput = input
+
+        guard let screen = screen else { return }
+
+        let updatedView = HintOverlayView(
+            hints: hints,
+            currentInput: currentInput,
+            screenBounds: screen.frame
+        )
+        hostingView?.rootView = updatedView
+    }
+
+    /// Dismisses the overlay window.
+    func dismiss() {
+        #if DEBUG
+        print("[HintOverlayWindow] dismiss called")
+        #endif
+
+        // Clear content view to release SwiftUI hosting view
+        contentView = nil
+        hostingView = nil
+
+        orderOut(nil)
+    }
+
+    /// Shows the overlay window.
+    func show() {
+        // Use orderFrontRegardless instead of makeKeyAndOrderFront
+        // because this window cannot become key (ignoresMouseEvents = true)
+        orderFrontRegardless()
+    }
+
+    // MARK: - NSWindow Overrides
+
+    /// Returns false because this overlay window should not become key.
+    /// Keyboard input is captured via global event monitoring instead.
+    override var canBecomeKey: Bool {
+        false
+    }
+}
+
+// MARK: - Multi-Screen Support
+
+extension HintOverlayWindow {
+    /// Creates overlay windows for all screens.
+    ///
+    /// - Parameter hints: The hint labels to display.
+    /// - Returns: An array of overlay windows, one for each screen.
+    static func createForAllScreens(hints: [HintLabel]) -> [HintOverlayWindow] {
+        NSScreen.screens.map { screen in
+            // Filter hints to only those visible on this screen
+            let screenHints = hints.filter { hint in
+                screen.frame.intersects(hint.frame)
+            }
+            return HintOverlayWindow(hints: screenHints, on: screen)
+        }
+    }
+}

--- a/Portal/Models/MenuItem.swift
+++ b/Portal/Models/MenuItem.swift
@@ -34,11 +34,9 @@ enum CommandType: String, Sendable {
 ///   the caller should handle `AXError` appropriately when the element is no longer valid.
 ///   Crawlers may cache results briefly to improve performance and help mitigate stale references.
 ///
-/// - Note: The `id` property is derived from `type.rawValue + "\0" + path.joined(separator: "\0")`.
-///   This ensures items of different types with the same path are still unique.
-///   MenuItems with empty paths will have minimal `id`, which could cause hash collisions if
-///   multiple empty-path items are used in Set or Dictionary collections. In practice, crawlers
-///   never create MenuItems with empty paths, as they only add items with non-empty titles.
+/// - Note: The `id` property uses a UUID generated at creation time to ensure uniqueness.
+///   This prevents issues when multiple elements have the same title and path
+///   (e.g., a "Blue" button and a "Blue" popup in System Settings Appearance).
 ///
 /// ## Thread Safety
 /// This type is marked as `@unchecked Sendable` because:
@@ -50,8 +48,11 @@ enum CommandType: String, Sendable {
 ///
 /// If `MenuItem` is ever accessed from non-main threads, this assumption must be revisited.
 struct MenuItem: Identifiable, @unchecked Sendable {
-    /// Unique identifier based on menu path.
-    let id: String
+    /// Unique identifier using UUID to ensure uniqueness.
+    ///
+    /// Previously used path-based ID which caused issues when multiple elements
+    /// had the same title (e.g., "Blue" button and "Blue" popup in System Settings).
+    let id: String = UUID().uuidString
 
     /// Display title of the menu item.
     let title: String
@@ -92,9 +93,6 @@ struct MenuItem: Identifiable, @unchecked Sendable {
         isEnabled: Bool,
         type: CommandType = .menu
     ) {
-        // Include type in ID to ensure items of different types with the same path are unique.
-        // Use null character as separator to avoid collisions with menu titles containing "/"
-        self.id = type.rawValue + "\0" + path.joined(separator: "\0")
         self.title = title
         self.path = path
         self.keyboardShortcut = keyboardShortcut

--- a/Portal/Services/AccessibilityHelper.swift
+++ b/Portal/Services/AccessibilityHelper.swift
@@ -1,0 +1,263 @@
+//
+//  AccessibilityHelper.swift
+//  Portal
+//
+//  Created by Claude Code on 2026/01/03.
+//
+
+import ApplicationServices
+import AppKit
+
+/// Utility functions for Accessibility API operations.
+///
+/// Provides common operations like retrieving element positions and sizes,
+/// which are used by hint mode to display labels at element locations.
+enum AccessibilityHelper {
+    /// Retrieves the screen frame of an accessibility element.
+    ///
+    /// - Parameter element: The accessibility element to get the frame for.
+    /// - Returns: The element's frame in screen coordinates (AppKit: bottom-left origin),
+    ///            or `nil` if the position or size cannot be retrieved.
+    ///
+    /// - Note: The Accessibility API uses top-left origin coordinates.
+    ///   This method converts to AppKit's bottom-left origin coordinate system.
+    static func getFrame(_ element: AXUIElement) -> CGRect? {
+        var positionRef: CFTypeRef?
+        var sizeRef: CFTypeRef?
+
+        // Get position attribute
+        guard AXUIElementCopyAttributeValue(
+            element,
+            kAXPositionAttribute as CFString,
+            &positionRef
+        ) == .success else {
+            return nil
+        }
+
+        // Get size attribute
+        guard AXUIElementCopyAttributeValue(
+            element,
+            kAXSizeAttribute as CFString,
+            &sizeRef
+        ) == .success else {
+            return nil
+        }
+
+        // Convert to CGPoint and CGSize
+        var position = CGPoint.zero
+        var size = CGSize.zero
+
+        guard let positionValue = positionRef,
+              CFGetTypeID(positionValue) == AXValueGetTypeID(),
+              AXValueGetValue(positionValue as! AXValue, .cgPoint, &position) else {
+            return nil
+        }
+
+        guard let sizeValue = sizeRef,
+              CFGetTypeID(sizeValue) == AXValueGetTypeID(),
+              AXValueGetValue(sizeValue as! AXValue, .cgSize, &size) else {
+            return nil
+        }
+
+        // Create rect in Accessibility coordinates (top-left origin)
+        let axRect = CGRect(origin: position, size: size)
+
+        // Convert to screen coordinates (bottom-left origin)
+        return convertToScreenCoordinates(axRect)
+    }
+
+    /// Retrieves frames for multiple accessibility elements.
+    ///
+    /// - Parameter elements: The accessibility elements to get frames for.
+    /// - Returns: An array of frames. Elements whose frames cannot be retrieved
+    ///            will have `.zero` as their frame.
+    static func getFrames(_ elements: [AXUIElement]) -> [CGRect] {
+        elements.map { getFrame($0) ?? .zero }
+    }
+
+    /// Converts a rect from Accessibility API coordinates to AppKit screen coordinates.
+    ///
+    /// The Accessibility API uses a coordinate system with the origin at the top-left
+    /// of the primary screen. AppKit uses a coordinate system with the origin at the
+    /// bottom-left of the primary screen.
+    ///
+    /// - Parameter axRect: A rect in Accessibility API coordinates (top-left origin).
+    /// - Returns: The rect in AppKit screen coordinates (bottom-left origin).
+    private static func convertToScreenCoordinates(_ axRect: CGRect) -> CGRect {
+        guard let primaryScreen = NSScreen.screens.first else {
+            return axRect
+        }
+
+        let screenHeight = primaryScreen.frame.height
+
+        // Flip Y coordinate: bottom = screenHeight - top - height
+        let convertedY = screenHeight - axRect.origin.y - axRect.size.height
+
+        return CGRect(
+            x: axRect.origin.x,
+            y: convertedY,
+            width: axRect.size.width,
+            height: axRect.size.height
+        )
+    }
+
+    /// Checks if an accessibility element is visible on screen.
+    ///
+    /// - Parameter element: The element to check.
+    /// - Returns: `true` if the element has a valid position and size, `false` otherwise.
+    static func isVisible(_ element: AXUIElement) -> Bool {
+        guard let frame = getFrame(element) else { return false }
+        return frame.width > 0 && frame.height > 0
+    }
+
+    /// Gets the title of an accessibility element.
+    ///
+    /// - Parameter element: The element to get the title from.
+    /// - Returns: The title string, or `nil` if not available.
+    static func getTitle(_ element: AXUIElement) -> String? {
+        var titleRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element,
+            kAXTitleAttribute as CFString,
+            &titleRef
+        ) == .success,
+              let title = titleRef as? String else {
+            return nil
+        }
+        return title
+    }
+
+    /// Gets the role of an accessibility element.
+    ///
+    /// - Parameter element: The element to get the role from.
+    /// - Returns: The role string (e.g., "AXButton"), or `nil` if not available.
+    static func getRole(_ element: AXUIElement) -> String? {
+        var roleRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element,
+            kAXRoleAttribute as CFString,
+            &roleRef
+        ) == .success,
+              let role = roleRef as? String else {
+            return nil
+        }
+        return role
+    }
+
+    /// Gets the main window frame of an application.
+    ///
+    /// - Parameter app: The running application to get the main window frame from.
+    /// - Returns: The main window's frame in screen coordinates, or `nil` if unavailable.
+    static func getMainWindowFrame(_ app: NSRunningApplication) -> CGRect? {
+        let axApp = AXUIElementCreateApplication(app.processIdentifier)
+
+        var mainWindowRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            axApp,
+            kAXMainWindowAttribute as CFString,
+            &mainWindowRef
+        ) == .success else {
+            return nil
+        }
+
+        // swiftlint:disable:next force_cast
+        let mainWindow = mainWindowRef as! AXUIElement
+        return getFrame(mainWindow)
+    }
+
+    /// Gets frames for all windows of an application.
+    ///
+    /// This includes main window, popup menus, floating panels, and dialogs.
+    ///
+    /// - Parameter app: The running application to get window frames from.
+    /// - Returns: Array of window frames in screen coordinates.
+    static func getAllWindowFrames(_ app: NSRunningApplication) -> [CGRect] {
+        let axApp = AXUIElementCreateApplication(app.processIdentifier)
+        var frames: [CGRect] = []
+
+        // Get all windows
+        var windowsRef: CFTypeRef?
+        if AXUIElementCopyAttributeValue(
+            axApp,
+            kAXWindowsAttribute as CFString,
+            &windowsRef
+        ) == .success, let windows = windowsRef as? [AXUIElement] {
+            for window in windows {
+                if let frame = getFrame(window) {
+                    frames.append(frame)
+                }
+            }
+        }
+
+        // Also check focused window (may include popups not in windows list)
+        var focusedWindowRef: CFTypeRef?
+        if AXUIElementCopyAttributeValue(
+            axApp,
+            kAXFocusedWindowAttribute as CFString,
+            &focusedWindowRef
+        ) == .success {
+            // swiftlint:disable:next force_cast
+            let focusedWindow = focusedWindowRef as! AXUIElement
+            if let focusedFrame = getFrame(focusedWindow) {
+                // Add if not already in frames
+                if !frames.contains(where: { $0 == focusedFrame }) {
+                    frames.append(focusedFrame)
+                }
+            }
+        }
+
+        // Fallback to main window if no windows found
+        if frames.isEmpty {
+            if let mainFrame = getMainWindowFrame(app) {
+                frames.append(mainFrame)
+            }
+        }
+
+        return frames
+    }
+
+    /// Checks if an element is visible within all its parent scroll containers.
+    ///
+    /// Elements inside scroll areas may have valid frames but be scrolled out of view.
+    /// This method walks up the parent hierarchy and checks if the element's frame
+    /// intersects with any parent AXScrollArea's visible bounds.
+    ///
+    /// - Parameter element: The element to check visibility for.
+    /// - Returns: `true` if the element is visible in all parent scroll containers,
+    ///            `false` if it's scrolled out of view.
+    static func isVisibleInScrollContainers(_ element: AXUIElement) -> Bool {
+        guard let elementFrame = getFrame(element) else { return false }
+
+        // Walk up parent hierarchy checking for scroll containers
+        var current = element
+        while let parent = getParent(current) {
+            if let role = getRole(parent), role == "AXScrollArea" {
+                if let parentFrame = getFrame(parent) {
+                    // Element must intersect with scroll area's visible bounds
+                    if !parentFrame.intersects(elementFrame) {
+                        return false
+                    }
+                }
+            }
+            current = parent
+        }
+        return true
+    }
+
+    /// Gets the parent element of an accessibility element.
+    ///
+    /// - Parameter element: The element to get the parent from.
+    /// - Returns: The parent element, or `nil` if not available.
+    private static func getParent(_ element: AXUIElement) -> AXUIElement? {
+        var parentRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element,
+            kAXParentAttribute as CFString,
+            &parentRef
+        ) == .success else {
+            return nil
+        }
+        // swiftlint:disable:next force_cast
+        return (parentRef as! AXUIElement)
+    }
+}

--- a/Portal/Services/WindowCrawler.swift
+++ b/Portal/Services/WindowCrawler.swift
@@ -26,6 +26,20 @@ enum WindowCrawlerError: Error, LocalizedError {
     }
 }
 
+/// Result of window crawling operation.
+///
+/// Contains the crawled items and metadata about the crawl context.
+struct WindowCrawlResult {
+    /// The crawled menu items.
+    let items: [MenuItem]
+
+    /// Whether a popup menu was detected.
+    ///
+    /// When `true`, the items are popup menu items (AXMenuItem) and should not
+    /// be filtered by window bounds, as popup menus can extend beyond the main window.
+    let isPopupMenu: Bool
+}
+
 /// Service for crawling window UI elements using Accessibility API.
 ///
 /// This service crawls actionable UI elements from an application's main window,
@@ -48,7 +62,9 @@ final class WindowCrawler {
     private static let maxDepth = 10
 
     /// Maximum number of items to return (performance safeguard).
-    private static let maxItems = 200
+    /// Increased from 200 to 500 to ensure player controls and other UI elements
+    /// are crawled even when there are many content items (e.g., search results).
+    private static let maxItems = 500
 
     /// Accessibility roles for container elements that should be traversed.
     private static let containerRoles: Set<String> = [
@@ -59,7 +75,9 @@ final class WindowCrawler {
         "AXSplitGroup",
         "AXGroup",
         "AXToolbar",
-        "AXSegmentedControl"
+        "AXSegmentedControl",
+        "AXMenu",
+        "AXMenuBar"
     ]
 
     /// Accessibility roles for actionable items we can interact with.
@@ -69,15 +87,25 @@ final class WindowCrawler {
         "AXOutlineRow",
         "AXStaticText",
         "AXButton",
-        "AXRadioButton"
+        "AXRadioButton",
+        "AXMenuItem",
+        "AXCheckBox",
+        "AXMenuButton",
+        "AXSwitch",
+        "AXPopUpButton",
+        "AXComboBox",
+        "AXTextField"
     ]
 
-    /// Crawls window elements from the main window of the specified application.
+    /// Crawls window elements from the application's windows.
+    ///
+    /// If AXMenuItem elements are found in the hierarchy (indicating a popup menu is open),
+    /// only those menu items are returned. Otherwise, crawls the main window normally.
     ///
     /// - Parameter app: The application to crawl window elements from.
-    /// - Returns: Array of menu items representing window UI elements.
+    /// - Returns: A `WindowCrawlResult` containing the items and whether a popup menu was detected.
     /// - Throws: WindowCrawlerError if crawling fails.
-    func crawlWindowElements(_ app: NSRunningApplication) async throws -> [MenuItem] {
+    func crawlWindowElements(_ app: NSRunningApplication) async throws -> WindowCrawlResult {
         guard AccessibilityService.isGranted else {
             throw WindowCrawlerError.accessibilityNotGranted
         }
@@ -85,42 +113,175 @@ final class WindowCrawler {
         let pid = app.processIdentifier
         let axApp = AXUIElementCreateApplication(pid)
 
+        var itemCount = 0
+
         // Get main window
         var mainWindowRef: CFTypeRef?
-        let result = AXUIElementCopyAttributeValue(
+        let mainWindowResult = AXUIElementCopyAttributeValue(
             axApp,
             kAXMainWindowAttribute as CFString,
             &mainWindowRef
         )
 
-        guard result == .success, let mainWindow = mainWindowRef else {
+        guard mainWindowResult == .success, let mainWindow = mainWindowRef else {
             throw WindowCrawlerError.mainWindowNotAccessible
         }
 
-        // The Accessibility API guarantees that kAXMainWindowAttribute returns an AXUIElement
-        // when AXUIElementCopyAttributeValue returns .success. The force cast is safe here
-        // because CoreFoundation types cannot use conditional casting (as? always succeeds).
         // swiftlint:disable:next force_cast
         let windowElement = mainWindow as! AXUIElement
-
-        // Get window title for path prefix
         let windowTitle = getTitle(from: windowElement) ?? app.localizedName ?? "Window"
 
-        // Crawl all window elements
-        var itemCount = 0
+        // First, check for AXMenuItem elements in the hierarchy
+        // If found, a popup menu is open - return only those items
+        let menuItems = collectMenuItems(in: windowElement, path: [windowTitle, "Menu"], itemCount: &itemCount)
+        if !menuItems.isEmpty {
+            #if DEBUG
+            print("[WindowCrawler] Popup menu detected - returning \(menuItems.count) menu items only")
+            #endif
+            return WindowCrawlResult(items: deduplicateItems(menuItems), isPopupMenu: true)
+        }
+
+        // No popup menu - crawl main window normally
+        #if DEBUG
+        print("[WindowCrawler] Crawling main window: '\(windowTitle)'")
+        #endif
+
         let allItems = crawlWindowInElement(windowElement, path: [windowTitle], depth: 0, itemCount: &itemCount)
 
-        // Deduplicate by path-based identifier (elements reached via different paths get different IDs)
-        var seenIds = Set<String>()
+        return WindowCrawlResult(items: deduplicateItems(allItems), isPopupMenu: false)
+    }
+
+    /// Collects all AXMenuItem elements from the hierarchy.
+    ///
+    /// This method recursively searches for AXMenuItem elements, which indicate
+    /// that a popup/context menu is currently open. Some apps (like Music) don't
+    /// wrap popup menus in an AXMenu element, so we detect by finding AXMenuItem directly.
+    ///
+    /// - Parameters:
+    ///   - element: The root element to search from.
+    ///   - path: The current path for item identification.
+    ///   - itemCount: Counter for total items found.
+    ///   - depth: Current recursion depth (default 0).
+    /// - Returns: Array of MenuItem objects representing popup menu items.
+    private func collectMenuItems(
+        in element: AXUIElement,
+        path: [String],
+        itemCount: inout Int,
+        depth: Int = 0
+    ) -> [MenuItem] {
+        guard depth < Self.maxDepth, itemCount < Self.maxItems else {
+            return []
+        }
+
+        var items: [MenuItem] = []
+
+        var childrenRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+              let children = childrenRef as? [AXUIElement] else {
+            return items
+        }
+
+        for child in children {
+            guard itemCount < Self.maxItems else { break }
+
+            guard let role = getRole(from: child) else { continue }
+
+            // Found an AXMenuItem - check if it's inside a proper AXMenu context
+            // This distinguishes real popup menus from AXMenuItem elements used elsewhere in the UI
+            // (e.g., sidebar navigation items that may have AXMenuItem role)
+            if role == "AXMenuItem" {
+                // Only treat as popup menu item if parent is AXMenu
+                var parentRef: CFTypeRef?
+                if AXUIElementCopyAttributeValue(child, kAXParentAttribute as CFString, &parentRef) == .success {
+                    // swiftlint:disable:next force_cast
+                    let parent = parentRef as! AXUIElement
+                    if let parentRole = getRole(from: parent), parentRole == "AXMenu" {
+                        let title = getTitle(from: child)
+                        let desc = getDescription(from: child)
+                        var displayTitle: String? = nil
+                        if let t = title, !t.isEmpty { displayTitle = t }
+                        else if let d = desc, !d.isEmpty { displayTitle = d }
+
+                        if let itemTitle = displayTitle, !itemTitle.isEmpty {
+                            let isEnabled = getIsEnabled(from: child)
+                            let currentPath = path + [itemTitle]
+
+                            #if DEBUG
+                            print("[WindowCrawler] Found popup menu item: '\(itemTitle)'")
+                            #endif
+
+                            let menuItem = MenuItem(
+                                title: itemTitle,
+                                path: currentPath,
+                                keyboardShortcut: nil,
+                                axElement: child,
+                                isEnabled: isEnabled,
+                                type: .window
+                            )
+                            items.append(menuItem)
+                            itemCount += 1
+                        }
+                    }
+                }
+            }
+
+            // Recursively search in all containers
+            if Self.containerRoles.contains(role) || hasChildren(child) {
+                let subItems = collectMenuItems(in: child, path: path, itemCount: &itemCount, depth: depth + 1)
+                items.append(contentsOf: subItems)
+            }
+        }
+
+        return items
+    }
+
+    /// Removes duplicate items based on their AXUIElement reference.
+    ///
+    /// Since MenuItem.id is now UUID-based (to support items with the same title),
+    /// we need to compare AXUIElement references to detect true duplicates.
+    /// Two MenuItems pointing to the same AXUIElement are considered duplicates.
+    private func deduplicateItems(_ items: [MenuItem]) -> [MenuItem] {
+        var seenElements: [AXUIElement] = []
         var uniqueItems: [MenuItem] = []
-        for item in allItems {
-            if !seenIds.contains(item.id) {
-                seenIds.insert(item.id)
+
+        for item in items {
+            // Check if we've already seen this AXUIElement
+            let isDuplicate = seenElements.contains { existing in
+                CFEqual(existing, item.axElement)
+            }
+
+            if !isDuplicate {
+                seenElements.append(item.axElement)
                 uniqueItems.append(item)
             }
         }
 
         return uniqueItems
+    }
+
+    /// Gets frame from an element (for comparison purposes).
+    private func getFrame(from element: AXUIElement) -> CGRect? {
+        var positionRef: CFTypeRef?
+        var sizeRef: CFTypeRef?
+
+        guard AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionRef) == .success,
+              AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeRef) == .success else {
+            return nil
+        }
+
+        var position = CGPoint.zero
+        var size = CGSize.zero
+
+        guard let posValue = positionRef,
+              CFGetTypeID(posValue) == AXValueGetTypeID(),
+              AXValueGetValue(posValue as! AXValue, .cgPoint, &position),
+              let sizeValue = sizeRef,
+              CFGetTypeID(sizeValue) == AXValueGetTypeID(),
+              AXValueGetValue(sizeValue as! AXValue, .cgSize, &size) else {
+            return nil
+        }
+
+        return CGRect(origin: position, size: size)
     }
 
     /// Crawls window elements from the currently active application.
@@ -131,9 +292,9 @@ final class WindowCrawler {
     ///   BEFORE showing the panel (as done in `AppDelegate.handleHotkeyPressed()`) and
     ///   use `crawlWindowElements(_:)` instead when possible.
     ///
-    /// - Returns: Array of menu items representing window UI elements.
+    /// - Returns: A `WindowCrawlResult` containing the items and whether a popup menu was detected.
     /// - Throws: WindowCrawlerError if crawling fails.
-    func crawlActiveApplicationWindow() async throws -> [MenuItem] {
+    func crawlActiveApplicationWindow() async throws -> WindowCrawlResult {
         guard AccessibilityService.isGranted else {
             throw WindowCrawlerError.accessibilityNotGranted
         }
@@ -199,11 +360,25 @@ final class WindowCrawler {
                 continue
             }
 
-            // Get title or description
+            // Get title or description - try multiple attributes for buttons
+            // Use first non-empty value (empty string is different from nil)
             let title = getTitle(from: child)
             let desc = getDescription(from: child)
             let value = getValue(from: child)
-            var displayTitle = title ?? desc ?? value
+            let help = getHelp(from: child)
+            var displayTitle: String? = nil
+            if let t = title, !t.isEmpty { displayTitle = t }
+            else if let d = desc, !d.isEmpty { displayTitle = d }
+            else if let v = value, !v.isEmpty { displayTitle = v }
+            else if let h = help, !h.isEmpty { displayTitle = h }
+
+            #if DEBUG
+            // Log all elements at depth 1-2 to see contents
+            if depth <= 2 {
+                let pathStr = path.joined(separator: " > ")
+                print("[WindowCrawler] depth=\(depth) role=\(role) title='\(title ?? "")' desc='\(desc ?? "")' help='\(help ?? "")' path=\(pathStr)")
+            }
+            #endif
 
             // For row-type elements without a direct title, look in children
             if (displayTitle == nil || displayTitle?.isEmpty == true) &&
@@ -211,11 +386,40 @@ final class WindowCrawler {
                 displayTitle = getTitleFromRowChildren(child)
             }
 
+            // For toggle switches and checkboxes, look in sibling elements for labels
+            // These elements typically have their label in a sibling AXStaticText element
+            if (displayTitle == nil || displayTitle?.isEmpty == true) &&
+               (role == "AXSwitch" || role == "AXCheckBox") {
+                displayTitle = getTitleFromSiblings(child)
+            }
+
+            // For text fields, try placeholder value first (e.g., "Find in Songs"),
+            // then fall back to sibling labels
+            if (displayTitle == nil || displayTitle?.isEmpty == true) && role == "AXTextField" {
+                displayTitle = getPlaceholderValue(from: child)
+                if displayTitle == nil || displayTitle?.isEmpty == true {
+                    displayTitle = getTitleFromSiblings(child)
+                }
+            }
+
             // Check if this is an actionable item
             var pathForChildren = path
             if Self.itemRoles.contains(role) {
                 let canAct = canPerformAction(on: child)
                 if let itemTitle = displayTitle, !itemTitle.isEmpty, canAct {
+                    // Skip section headers (like "Library", "Store", "Playlists" in Music app)
+                    // These have AXPress action but don't actually do anything
+                    if isSectionHeader(child, role: role) {
+                        #if DEBUG
+                        print("[WindowCrawler] Skipping section header: '\(itemTitle)' (role: \(role))")
+                        #endif
+                        continue
+                    }
+
+                    #if DEBUG
+                    print("[WindowCrawler] Adding item: '\(itemTitle)' (role: \(role))")
+                    #endif
+
                     let isEnabled = getIsEnabled(from: child)
                     let currentPath = path + [itemTitle]
                     pathForChildren = currentPath
@@ -234,8 +438,21 @@ final class WindowCrawler {
             }
 
             // Recurse into containers or elements with children
-            if Self.containerRoles.contains(role) || hasChildren(child) {
-                let subItems = crawlWindowInElement(child, path: pathForChildren, depth: depth + 1, itemCount: &itemCount)
+            // Skip recursion for actionable leaf items (they shouldn't have crawlable children)
+            let isLeafItem = role == "AXMenuButton" || role == "AXCheckBox" ||
+                             role == "AXSwitch" || role == "AXPopUpButton" ||
+                             role == "AXComboBox" || role == "AXTextField"
+            if !isLeafItem && (Self.containerRoles.contains(role) || hasChildren(child)) {
+                // For containers, include the container name in the path to differentiate
+                // items with the same title in different locations (e.g., "iTunes Store" in
+                // both sidebar and toolbar)
+                var pathForContainer = pathForChildren
+                if Self.containerRoles.contains(role) {
+                    if let containerName = getContainerName(child, role: role), !containerName.isEmpty {
+                        pathForContainer = pathForChildren + [containerName]
+                    }
+                }
+                let subItems = crawlWindowInElement(child, path: pathForContainer, depth: depth + 1, itemCount: &itemCount)
                 items.append(contentsOf: subItems)
             }
         }
@@ -271,6 +488,125 @@ final class WindowCrawler {
                actions.contains("AXSelect") ||
                actions.contains("AXConfirm") ||
                actions.contains("AXShowDefaultUI")
+    }
+
+    /// Checks if an element is a section header that should be excluded.
+    ///
+    /// Section headers are elements that:
+    /// - Are AXRow/AXOutlineRow with disclosure level 0 AND have a disclosure indicator
+    ///   (expandable section headers like "Library", "Store", "Playlists")
+    /// - Are standalone AXStaticText not inside interactive containers
+    ///
+    /// Navigation items at disclosure level 0 WITHOUT disclosure indicators
+    /// (like "Search", "Home", "Radio") are NOT section headers and should be included.
+    ///
+    /// - Parameters:
+    ///   - element: The element to check.
+    ///   - role: The element's role.
+    /// - Returns: `true` if this is a section header that should be excluded.
+    private func isSectionHeader(_ element: AXUIElement, role: String) -> Bool {
+        // Get element title for debugging
+        let elementTitle = getTitle(from: element) ?? getValue(from: element) ?? "unknown"
+
+        // For AXRow and AXOutlineRow, check if it's an expandable section header
+        if role == "AXRow" || role == "AXOutlineRow" {
+            // Check disclosure level - section headers typically have level 0
+            var disclosureLevelRef: CFTypeRef?
+            if AXUIElementCopyAttributeValue(
+                element,
+                "AXDisclosureLevel" as CFString,
+                &disclosureLevelRef
+            ) == .success, let level = disclosureLevelRef as? Int {
+                // Level 0 could be either a section header or a navigation item
+                // Section headers have a disclosure triangle (AXDisclosing attribute or disclosure child)
+                if level == 0 {
+                    // Check for AXDisclosing attribute VALUE (true = expanded section header)
+                    // Navigation items may have AXDisclosing = false or no children
+                    var disclosingRef: CFTypeRef?
+                    if AXUIElementCopyAttributeValue(
+                        element,
+                        "AXDisclosing" as CFString,
+                        &disclosingRef
+                    ) == .success, let isDisclosing = disclosingRef as? Bool {
+                        #if DEBUG
+                        print("[WindowCrawler] isSectionHeader: '\(elementTitle)' level 0, AXDisclosing=\(isDisclosing)")
+                        #endif
+                        // Only skip if actually expanded (showing children)
+                        if isDisclosing {
+                            return true
+                        }
+                        // AXDisclosing = false means it's a navigation item, not a section header
+                        return false
+                    }
+
+                    // Also check for disclosure triangle child element
+                    if hasDisclosureTriangle(element) {
+                        #if DEBUG
+                        print("[WindowCrawler] isSectionHeader: '\(elementTitle)' level 0 with disclosure triangle → section header")
+                        #endif
+                        return true
+                    }
+
+                    #if DEBUG
+                    print("[WindowCrawler] isSectionHeader: '\(elementTitle)' level 0 without disclosure → navigation item")
+                    #endif
+                    return false
+                }
+
+                #if DEBUG
+                print("[WindowCrawler] isSectionHeader: '\(elementTitle)' level \(level) → not a section header")
+                #endif
+            }
+            return false
+        }
+
+        // For AXStaticText, check if parent is interactive
+        if role == "AXStaticText" {
+            var parentRef: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(
+                element,
+                kAXParentAttribute as CFString,
+                &parentRef
+            ) == .success else {
+                return true
+            }
+
+            // swiftlint:disable:next force_cast
+            let parent = parentRef as! AXUIElement
+            guard let parentRole = getRole(from: parent) else {
+                return true
+            }
+
+            let interactiveParentRoles: Set<String> = [
+                "AXRow", "AXCell", "AXOutlineRow", "AXButton"
+            ]
+            return !interactiveParentRoles.contains(parentRole)
+        }
+
+        return false
+    }
+
+    /// Checks if an element has a disclosure triangle child.
+    ///
+    /// Disclosure triangles are used to expand/collapse section headers.
+    private func hasDisclosureTriangle(_ element: AXUIElement) -> Bool {
+        let children = getChildren(element)
+        for child in children {
+            if let role = getRole(from: child) {
+                // Check for disclosure triangle or button that controls disclosure
+                if role == "AXDisclosureTriangle" || role == "AXOutline" {
+                    return true
+                }
+                // Also check subrole
+                var subroleRef: CFTypeRef?
+                if AXUIElementCopyAttributeValue(child, kAXSubroleAttribute as CFString, &subroleRef) == .success,
+                   let subrole = subroleRef as? String,
+                   subrole == "AXOutlineRowDisclosure" || subrole == "AXDisclosureTriangle" {
+                    return true
+                }
+            }
+        }
+        return false
     }
 
     /// Gets the title attribute from an accessibility element.
@@ -347,6 +683,50 @@ final class WindowCrawler {
         return nil
     }
 
+    /// Gets the title from sibling elements (for toggle switches and checkboxes).
+    ///
+    /// AXSwitch and AXCheckBox elements typically don't have their own title attribute.
+    /// Instead, the label is in a sibling AXStaticText element within the same parent container.
+    ///
+    /// - Parameter element: The AXSwitch or AXCheckBox element.
+    /// - Returns: The title found in a sibling element, or nil if not found.
+    private func getTitleFromSiblings(_ element: AXUIElement) -> String? {
+        // Get the parent element
+        var parentRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXParentAttribute as CFString, &parentRef) == .success else {
+            return nil
+        }
+        // swiftlint:disable:next force_cast
+        let parent = parentRef as! AXUIElement
+
+        // Get sibling elements (children of parent)
+        let siblings = getChildren(parent)
+
+        // Look for AXStaticText siblings that contain the label
+        for sibling in siblings {
+            // Skip the element itself
+            if CFEqual(sibling, element) {
+                continue
+            }
+
+            if let role = getRole(from: sibling), role == "AXStaticText" {
+                if let value = getValue(from: sibling), !value.isEmpty {
+                    return value
+                }
+                if let title = getTitle(from: sibling), !title.isEmpty {
+                    return title
+                }
+            }
+        }
+
+        // Fallback: try the parent's description
+        if let desc = getDescription(from: parent), !desc.isEmpty {
+            return desc
+        }
+
+        return nil
+    }
+
     /// Gets the role attribute from an accessibility element.
     private func getRole(from element: AXUIElement) -> String? {
         var roleRef: CFTypeRef?
@@ -374,6 +754,26 @@ final class WindowCrawler {
         return valueRef as? String
     }
 
+    /// Gets the help attribute from an accessibility element.
+    /// This is often used for button tooltips/accessibility labels.
+    private func getHelp(from element: AXUIElement) -> String? {
+        var helpRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXHelpAttribute as CFString, &helpRef) == .success else {
+            return nil
+        }
+        return helpRef as? String
+    }
+
+    /// Gets the placeholder value attribute from an accessibility element.
+    /// This is typically used for text fields to show hint text (e.g., "Find in Songs").
+    private func getPlaceholderValue(from element: AXUIElement) -> String? {
+        var placeholderRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, "AXPlaceholderValue" as CFString, &placeholderRef) == .success else {
+            return nil
+        }
+        return placeholderRef as? String
+    }
+
     /// Gets the enabled state from an element.
     private func getIsEnabled(from element: AXUIElement) -> Bool {
         var enabledRef: CFTypeRef?
@@ -381,5 +781,29 @@ final class WindowCrawler {
             return true  // Default to enabled if we can't determine
         }
         return (enabledRef as? Bool) ?? true
+    }
+
+    /// Gets a display name for a container element to include in item paths.
+    ///
+    /// This ensures that items with the same title but in different containers
+    /// (e.g., "iTunes Store" in sidebar vs toolbar) have unique paths and IDs.
+    ///
+    /// - Parameters:
+    ///   - element: The container element.
+    ///   - role: The container's accessibility role.
+    /// - Returns: A name for the container, or nil if no name should be added.
+    private func getContainerName(_ element: AXUIElement, role: String) -> String? {
+        // First, try the element's description (e.g., "Sidebar" for AXOutline)
+        if let desc = getDescription(from: element), !desc.isEmpty {
+            return desc
+        }
+
+        // Fall back to default names for certain container types
+        switch role {
+        case "AXToolbar":
+            return "Toolbar"
+        default:
+            return nil
+        }
     }
 }

--- a/Portal/Settings/HotkeyConfiguration.swift
+++ b/Portal/Settings/HotkeyConfiguration.swift
@@ -13,6 +13,7 @@ enum ModifierKey: String, CaseIterable, Identifiable {
     case command = "Command"
     case control = "Control"
     case shift = "Shift"
+    case none = "None"
 
     var id: String { rawValue }
 
@@ -23,6 +24,7 @@ enum ModifierKey: String, CaseIterable, Identifiable {
         case .command: return "⌘"
         case .control: return "⌃"
         case .shift: return "⇧"
+        case .none: return ""
         }
     }
 
@@ -33,6 +35,7 @@ enum ModifierKey: String, CaseIterable, Identifiable {
         case .command: return .command
         case .control: return .control
         case .shift: return .shift
+        case .none: return []
         }
     }
 
@@ -43,7 +46,13 @@ enum ModifierKey: String, CaseIterable, Identifiable {
         case .command: return .maskCommand
         case .control: return .maskControl
         case .shift: return .maskShift
+        case .none: return []
         }
+    }
+
+    /// Whether this modifier requires no modifier key to be pressed.
+    var isNone: Bool {
+        self == .none
     }
 }
 

--- a/Portal/UI/CommandPaletteViewModel.swift
+++ b/Portal/UI/CommandPaletteViewModel.swift
@@ -189,12 +189,13 @@ final class CommandPaletteViewModel: ObservableObject {
             // Step 2: Load window elements (sidebar, toolbar, content)
             // Failures are silently ignored - menus alone are sufficient
             do {
-                let windowItems: [MenuItem]
+                let crawlResult: WindowCrawlResult
                 if let targetApp = app {
-                    windowItems = try await windowCrawler.crawlWindowElements(targetApp)
+                    crawlResult = try await windowCrawler.crawlWindowElements(targetApp)
                 } else {
-                    windowItems = try await windowCrawler.crawlActiveApplicationWindow()
+                    crawlResult = try await windowCrawler.crawlActiveApplicationWindow()
                 }
+                let windowItems = crawlResult.items
 
                 // Check for cancellation before updating state
                 guard !Task.isCancelled else { return }

--- a/PortalTests/HintLabelGeneratorTests.swift
+++ b/PortalTests/HintLabelGeneratorTests.swift
@@ -1,0 +1,176 @@
+//
+//  HintLabelGeneratorTests.swift
+//  PortalTests
+//
+//  Created by Claude Code on 2026/01/03.
+//
+
+import ApplicationServices
+import CoreGraphics
+import Testing
+@testable import Portal
+
+struct HintLabelGeneratorTests {
+
+    // MARK: - Label Generation Tests
+
+    @Test
+    func testGenerateLabelsEmpty() {
+        let labels = HintLabelGenerator.generateLabels(count: 0)
+        #expect(labels.isEmpty)
+    }
+
+    @Test
+    func testGenerateLabelsNegative() {
+        let labels = HintLabelGenerator.generateLabels(count: -5)
+        #expect(labels.isEmpty)
+    }
+
+    @Test
+    func testGenerateLabelsSingleCharacter() {
+        let labels = HintLabelGenerator.generateLabels(count: 5)
+        #expect(labels == ["A", "B", "C", "D", "E"])
+    }
+
+    @Test
+    func testGenerateLabelsFullAlphabet() {
+        // Note: "F" is excluded from the alphabet, so we have 25 single-character labels
+        let labels = HintLabelGenerator.generateLabels(count: 25)
+        #expect(labels.count == 25)
+        #expect(labels.first == "A")
+        #expect(labels.last == "Z")
+        #expect(!labels.contains("F"))  // F should not be in the labels
+    }
+
+    @Test
+    func testGenerateLabelsTwoCharacters() {
+        // When count > 25, ALL labels are two-character (no overlap with single-char)
+        let labels = HintLabelGenerator.generateLabels(count: 28)
+        #expect(labels.count == 28)
+        #expect(labels[0] == "AA")  // Starts with two-char
+        #expect(labels[1] == "AB")
+        #expect(labels[24] == "AZ")  // 25 labels from AA to AZ (no AF)
+        #expect(labels[25] == "BA")
+        #expect(labels[26] == "BB")
+        #expect(labels[27] == "BC")
+    }
+
+    @Test
+    func testGenerateLabelsLargeCount() {
+        let labels = HintLabelGenerator.generateLabels(count: 100)
+        #expect(labels.count == 100)
+        // When count > 25, ALL labels are two-character
+        #expect(labels[0] == "AA")
+        #expect(labels[24] == "AZ")  // 25 two-char labels starting with A (no AF)
+        #expect(labels[25] == "BA")
+        #expect(labels[49] == "BZ")  // 25 two-char labels starting with B (no BF)
+        #expect(labels[50] == "CA")
+    }
+
+    // MARK: - Filter Tests
+
+    @Test
+    func testFilterHintsEmptyInput() {
+        let hints = createTestHints(["A", "B", "C"])
+        let filtered = HintLabelGenerator.filterHints(hints, by: "")
+        #expect(filtered.count == 3)
+    }
+
+    @Test
+    func testFilterHintsExactMatch() {
+        let hints = createTestHints(["A", "B", "AB", "AC"])
+        let filtered = HintLabelGenerator.filterHints(hints, by: "A")
+        #expect(filtered.count == 3)
+        #expect(filtered.map { $0.label } == ["A", "AB", "AC"])
+    }
+
+    @Test
+    func testFilterHintsCaseInsensitive() {
+        let hints = createTestHints(["A", "B", "AB"])
+        let filtered = HintLabelGenerator.filterHints(hints, by: "a")
+        #expect(filtered.count == 2)
+        #expect(filtered.map { $0.label } == ["A", "AB"])
+    }
+
+    @Test
+    func testFilterHintsNoMatch() {
+        let hints = createTestHints(["A", "B", "C"])
+        let filtered = HintLabelGenerator.filterHints(hints, by: "X")
+        #expect(filtered.isEmpty)
+    }
+
+    @Test
+    func testFilterHintsTwoCharacterInput() {
+        let hints = createTestHints(["A", "AB", "AC", "BA"])
+        let filtered = HintLabelGenerator.filterHints(hints, by: "AB")
+        #expect(filtered.count == 1)
+        #expect(filtered.first?.label == "AB")
+    }
+
+    // MARK: - Unique Match Tests
+
+    @Test
+    func testFindUniqueMatchSingle() {
+        let hints = createTestHints(["A", "B", "C"])
+        let match = HintLabelGenerator.findUniqueMatch(in: hints, for: "A")
+        #expect(match?.label == "A")
+    }
+
+    @Test
+    func testFindUniqueMatchMultipleCandidates() {
+        let hints = createTestHints(["A", "AB", "AC"])
+        let match = HintLabelGenerator.findUniqueMatch(in: hints, for: "A")
+        #expect(match == nil)
+    }
+
+    @Test
+    func testFindUniqueMatchNoMatch() {
+        let hints = createTestHints(["A", "B", "C"])
+        let match = HintLabelGenerator.findUniqueMatch(in: hints, for: "X")
+        #expect(match == nil)
+    }
+
+    // MARK: - Exact Match Tests
+
+    @Test
+    func testFindExactMatchFound() {
+        let hints = createTestHints(["A", "AB", "ABC"])
+        let match = HintLabelGenerator.findExactMatch(in: hints, for: "AB")
+        #expect(match?.label == "AB")
+    }
+
+    @Test
+    func testFindExactMatchCaseInsensitive() {
+        let hints = createTestHints(["AB"])
+        let match = HintLabelGenerator.findExactMatch(in: hints, for: "ab")
+        #expect(match?.label == "AB")
+    }
+
+    @Test
+    func testFindExactMatchNotFound() {
+        let hints = createTestHints(["A", "AB", "ABC"])
+        let match = HintLabelGenerator.findExactMatch(in: hints, for: "AC")
+        #expect(match == nil)
+    }
+
+    // MARK: - Helper
+
+    private func createTestHints(_ labels: [String]) -> [HintLabel] {
+        let dummyElement = AXUIElementCreateSystemWide()
+        return labels.enumerated().map { index, label in
+            let menuItem = MenuItem(
+                title: "Test \(label)",
+                path: ["Test", "Test \(label)"],
+                keyboardShortcut: nil,
+                axElement: dummyElement,
+                isEnabled: true,
+                type: .window
+            )
+            return HintLabel(
+                label: label,
+                frame: CGRect(x: CGFloat(index * 100), y: 0, width: 100, height: 20),
+                menuItem: menuItem
+            )
+        }
+    }
+}

--- a/PortalTests/HotkeyConfigurationTests.swift
+++ b/PortalTests/HotkeyConfigurationTests.swift
@@ -45,6 +45,7 @@ struct HotkeyConfigurationTests {
         #expect(ModifierKey.command.eventModifier == .command)
         #expect(ModifierKey.control.eventModifier == .control)
         #expect(ModifierKey.shift.eventModifier == .shift)
+        #expect(ModifierKey.none.eventModifier == [])
     }
 
     @Test
@@ -53,6 +54,7 @@ struct HotkeyConfigurationTests {
         #expect(ModifierKey.command.cgEventMask == .maskCommand)
         #expect(ModifierKey.control.cgEventMask == .maskControl)
         #expect(ModifierKey.shift.cgEventMask == .maskShift)
+        #expect(ModifierKey.none.cgEventMask == [])
     }
 
     @Test
@@ -61,6 +63,7 @@ struct HotkeyConfigurationTests {
         #expect(ModifierKey.command.symbol == "⌘")
         #expect(ModifierKey.control.symbol == "⌃")
         #expect(ModifierKey.shift.symbol == "⇧")
+        #expect(ModifierKey.none.symbol == "")
     }
 
     @Test
@@ -69,17 +72,19 @@ struct HotkeyConfigurationTests {
         #expect(ModifierKey.command.rawValue == "Command")
         #expect(ModifierKey.control.rawValue == "Control")
         #expect(ModifierKey.shift.rawValue == "Shift")
+        #expect(ModifierKey.none.rawValue == "None")
     }
 
     @Test
     func testModifierKeyCaseIterable() {
         let allCases = ModifierKey.allCases
 
-        #expect(allCases.count == 4)
+        #expect(allCases.count == 5)
         #expect(allCases.contains(.option))
         #expect(allCases.contains(.command))
         #expect(allCases.contains(.control))
         #expect(allCases.contains(.shift))
+        #expect(allCases.contains(.none))
     }
 
     // MARK: - HotkeyKey Tests

--- a/PortalTests/MenuItemTests.swift
+++ b/PortalTests/MenuItemTests.swift
@@ -17,7 +17,7 @@ struct MenuItemTests {
     }
 
     @Test
-    func testIdGenerationFromPath() {
+    func testIdIsUUID() {
         let element = createDummyElement()
         let item = MenuItem(
             title: "New",
@@ -27,8 +27,9 @@ struct MenuItemTests {
             isEnabled: true
         )
 
-        // ID should be type + null + path joined with null character
-        #expect(item.id == "menu\0File\0New")
+        // ID should be a valid UUID string (36 characters with hyphens)
+        #expect(item.id.count == 36)
+        #expect(UUID(uuidString: item.id) != nil)
     }
 
     @Test
@@ -99,9 +100,10 @@ struct MenuItemTests {
             isEnabled: true
         )
 
-        // Same ID should produce equal items and same hash
-        #expect(item1 == item2)
-        #expect(item1.hashValue == item2.hashValue)
+        // Each MenuItem has a unique UUID, so they are NOT equal even with same path
+        // This is intentional to support items with the same title (e.g., "Blue" button and "Blue" popup)
+        #expect(item1 != item2)
+        #expect(item1.hashValue != item2.hashValue)
     }
 
     @Test
@@ -167,8 +169,8 @@ struct MenuItemTests {
         )
 
         #expect(item.pathString == "")
-        // ID includes type prefix even with empty path
-        #expect(item.id == "menu\0")
+        // ID is a UUID regardless of path
+        #expect(UUID(uuidString: item.id) != nil)
     }
 
     @Test
@@ -194,8 +196,9 @@ struct MenuItemTests {
         var set: Set<MenuItem> = [item1]
         set.insert(item2)
 
-        // Same ID means same item, so set should have only 1 element
-        #expect(set.count == 1)
+        // Each MenuItem has unique UUID, so set should have 2 elements
+        // This is intentional to support items with the same title
+        #expect(set.count == 2)
     }
 
     // MARK: - CommandType Tests
@@ -231,7 +234,7 @@ struct MenuItemTests {
     }
 
     @Test
-    func testIdIncludesType() {
+    func testIdIsUUIDForDifferentTypes() {
         let element = createDummyElement()
 
         let menuItem = MenuItem(
@@ -252,10 +255,10 @@ struct MenuItemTests {
             type: .window
         )
 
-        // Same path but different types should produce different IDs
+        // Each MenuItem has unique UUID regardless of type
         #expect(menuItem.id != windowItem.id)
-        #expect(menuItem.id.hasPrefix("menu\0"))
-        #expect(windowItem.id.hasPrefix("window\0"))
+        #expect(UUID(uuidString: menuItem.id) != nil)
+        #expect(UUID(uuidString: windowItem.id) != nil)
     }
 
     @Test
@@ -366,10 +369,10 @@ struct MenuItemTests {
             type: .window
         )
 
-        // Same path but different types should produce different IDs
+        // Each MenuItem has unique UUID regardless of type
         #expect(menuItem.id != windowItem.id)
-        #expect(menuItem.id.hasPrefix("menu\0"))
-        #expect(windowItem.id.hasPrefix("window\0"))
+        #expect(UUID(uuidString: menuItem.id) != nil)
+        #expect(UUID(uuidString: windowItem.id) != nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- 単独Fキーでヒントモード起動（Vimiumライク）
- A-Z, AA-AZ式ラベル生成で操作可能要素にヒント表示
- AXTextField（テキストフィールド）のプレースホルダー対応

## Changes
- `Portal/HintMode/`: ヒントモード関連モジュール新規作成
- `WindowCrawler`: AXPlaceholderValue属性からテキストフィールドのラベル取得
- `CommandExecutor`: プレースホルダー値の検証対応
- `AccessibilityHelper`: 位置情報取得ユーティリティ

## Test plan
- [x] 全ユニットテストがパス
- [x] Musicアプリでヒントモード動作確認
- [x] テキストフィールド（Find in Songs）にラベル表示・フォーカス設定確認

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)