### PR TITLE
#110 設定画面のHint Modeホットキー設定を修正

### DIFF
--- a/Portal/Settings/SettingsView.swift
+++ b/Portal/Settings/SettingsView.swift
@@ -76,15 +76,13 @@ struct GeneralSettingsView: View {
                     .frame(width: 100)
                 }
 
-                if selectedModifier.wrappedValue == .none {
-                    Text("Current: \(selectedKey.wrappedValue.rawValue)")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                } else {
-                    Text("Current: \(selectedModifier.wrappedValue.symbol) \(selectedKey.wrappedValue.rawValue)")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
+                Text(
+                    selectedModifier.wrappedValue == .none
+                    ? "Current: \(selectedKey.wrappedValue.rawValue)"
+                    : "Current: \(selectedModifier.wrappedValue.symbol) \(selectedKey.wrappedValue.rawValue)"
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
             } header: {
                 Text("Hint Mode")
             }


### PR DESCRIPTION
## Summary

- @AppStorageのデフォルト値をHotkeyConfiguration.defaultと一致させる（Fキー単独）
- 修飾キーなし（.none）選択時は「+」を非表示に変更
- 「Current:」表示を修飾キー有無に応じて適切に表示

## Review scope

このPRでレビューしてほしいこと:
- デフォルト値の変更が正しく行われているか
- UIの表示が適切か（修飾キーなし時の「+」非表示、Current表示）

## Test plan

- [x] デフォルト状態で「F」キー単独が選択されていること
- [x] 修飾キーなし選択時、「+」が非表示になること
- [x] 「Current:」表示が適切に更新されること（修飾キーなし: "F"、あり: "⌥ F"）
- [x] 修飾キーあり選択時、従来通り「⌥ + A」形式で表示されること
- [x] 設定変更後、ホットキーが正しく動作すること

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)