### PR TITLE
#111 ウィンドウディアクティベート時にヒントモードを自動終了

### DIFF
--- a/Portal/HintMode/HintModeController.swift
+++ b/Portal/HintMode/HintModeController.swift
@@ -502,9 +502,7 @@ final class HintModeController {
                 #if DEBUG
                 print("[HintModeController] App switched to \(activatedApp.localizedName ?? "unknown"), deactivating")
                 #endif
-                Task { @MainActor in
-                    self.deactivate()
-                }
+                self.deactivate()
             }
         }
     }


### PR DESCRIPTION
## Summary
- `NSWorkspace.didActivateApplicationNotification` を監視し、アクティブアプリが変更されたらヒントモードを自動終了
- HintModeController内で監視を完結（SRPに従い、ヒントモードの終了条件は同クラスで管理）
- ヒントモードがアクティブな間だけ監視（効率的）

## Review scope
このPRでレビューしてほしいこと:
- `NSWorkspace.didActivateApplicationNotification` の使い方が適切か
- `processIdentifier` によるアプリ比較が適切か
- メモリリーク対策（`[weak self]` とobserverの解除）が適切か

このPRでレビュー不要なこと:
- 既存のヒントモード終了条件（ESC、ホットキー再押下、ヒント選択）は変更なし

## Test plan
- [x] ヒントモードを起動し、Cmd+Tab で別アプリに切り替え → ヒントラベルが消えることを確認
- [x] ヒントモードを起動し、マウスで別アプリをクリック → ヒントラベルが消えることを確認
- [x] ESCキー、ホットキー再押下、ヒント選択による終了が引き続き動作することを確認

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)