### PR TITLE
#115 マルチモニター環境でヒントラベルを正しく表示

### DIFF
--- a/Portal/HintMode/HintModeController.swift
+++ b/Portal/HintMode/HintModeController.swift
@@ -228,11 +228,21 @@ final class HintModeController {
             print("[HintModeController] Created \(hints.count) hints")
             #endif
 
-            // Create and show overlay windows
-            guard let screen = NSScreen.main else { return }
-            let overlayWindow = HintOverlayWindow(hints: hints, on: screen)
-            overlayWindow.show()
-            overlayWindows = [overlayWindow]
+            // Create and show overlay windows for all screens
+            overlayWindows = HintOverlayWindow.createForAllScreens(hints: hints)
+            guard !overlayWindows.isEmpty else {
+                #if DEBUG
+                print("[HintModeController] No screens available for overlay")
+                #endif
+                return
+            }
+            for window in overlayWindows {
+                window.show()
+            }
+
+            #if DEBUG
+            print("[HintModeController] Created \(overlayWindows.count) overlay windows for \(NSScreen.screens.count) screens")
+            #endif
 
             // Start keyboard monitoring
             startKeyboardMonitor()

--- a/Portal/HintMode/HintOverlayView.swift
+++ b/Portal/HintMode/HintOverlayView.swift
@@ -32,8 +32,8 @@ struct HintOverlayView: View {
                 ForEach(filteredHints) { hint in
                     HintLabelView(hint: hint, input: currentInput)
                         .position(
-                            x: hint.frame.minX + 10,
-                            y: geometry.size.height - hint.frame.maxY + 10
+                            x: hint.frame.minX - screenBounds.minX + 10,
+                            y: screenBounds.maxY - hint.frame.maxY + 10
                         )
                 }
             }


### PR DESCRIPTION
## Summary
- HintModeControllerで`createForAllScreens()`を使用して全スクリーンにオーバーレイを作成
- HintOverlayViewでグローバル座標をスクリーンローカル座標に変換

## Review scope
このPRでレビューしてほしいこと:
- マルチモニター対応の実装が正しいか
- 座標変換のロジックが正しいか

このPRでレビュー不要なこと:
- 既存の`createForAllScreens()`メソッドの実装（変更なし）

## Test plan
- [x] デュアルモニター（横並び）: 両方のモニターでヒントが正しく表示される
- [x] デュアルモニター（縦並び）: 両方のモニターでヒントが正しく表示される
- [x] シングルモニター: 既存機能が壊れていない

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)