### PR TITLE
#121 Electronアプリ（Slack、VS Code）のサポートを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,17 @@ Portal/
 - [x] ツールバー/セグメントコントロール（`AXToolbar`/`AXSegmentedControl`）走査（#95, #101）
 - [x] コンテンツ領域（`AXButton`/`AXGroup`/`AXRadioButton`）走査（#91, #95）
 - [x] チェックボックス/スイッチ（`AXCheckBox`/`AXSwitch`）実行（#109）
+- [x] Electronアプリ（`AXWebArea`/`AXTabGroup`）走査（#121）
+
+### Electronアプリ対応
+- [x] `AXWebArea`をコンテナロールに追加（#121）
+- [x] `AXTabGroup`をコンテナロールに追加（#121）
+- [x] `maxDepth`を20に増加（深いネスト構造対応）（#121）
+
+| アプリ | バンドルID | 対応状況 |
+|--------|-----------|---------|
+| Slack | com.tinyspeck.slackmacgap | ✅ 対応 |
+| VS Code | com.microsoft.VSCode | ✅ 対応 |
 
 ### ヒントモード（Vimiumライク）
 - [x] ホットキーでヒントモード起動（#104, #107）


### PR DESCRIPTION
## Summary
- Electronアプリ（Slack、VS Code）でヒントモードが動作するよう対応
- `maxDepth`を10から20に増加（深いネスト構造対応）
- `AXWebArea`と`AXTabGroup`をコンテナロールに追加

## 変更内容

| 変更 | 理由 |
|------|------|
| `maxDepth`: 10 → 20 | ElectronのAXWebArea内は15階層以上深い |
| `containerRoles`に`AXWebArea`追加 | Chromiumウェブコンテンツ領域を走査 |
| `containerRoles`に`AXTabGroup`追加 | タブグループ内の要素を走査 |
| デバッグログ追加 | Electronアプリ調査用（開発中のみ） |

## テスト結果

| アプリ | 認識数 | 主な要素 |
|--------|--------|---------|
| Slack | 15 | Home, DMs, Activity, Search, Help等 |
| VS Code | 35 | Explorer, Search, Source Control, ステータスバー等 |

## Review scope
このPRでレビューしてほしいこと:
- maxDepth増加によるパフォーマンスへの影響
- コンテナロール追加の妥当性

このPRでレビュー不要なこと:
- デバッグログは開発中のため残しています（今後のIssueで削除予定）

## Test plan
- [x] Slackでヒントモードが動作し、15個以上の要素が認識される
- [x] VS Codeでヒントモードが動作し、35個以上の要素が認識される
- [x] 既存のネイティブアプリ（Apple Music等）が引き続き動作する
- [x] ユニットテストがパスする

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)