### PR TITLE
#148 プログレッシブレンダリングでヒントラベルを逐次表示

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,10 +65,10 @@ Portal/
 │   └── HintExecutionError.swift # Hint Mode実行エラー
 ├── HintMode/
 │   ├── HintLabel.swift            # ヒントラベルのデータモデル
-│   ├── HintLabelGenerator.swift   # A-Z, AA-AZ式ラベル生成
+│   ├── HintLabelGenerator.swift   # AA-ZZ式2文字ラベル生成（インデックスベース/一括生成両対応）
 │   ├── HintOverlayView.swift      # SwiftUIラベル描画
-│   ├── HintOverlayWindow.swift    # オーバーレイウィンドウ管理
-│   └── HintModeController.swift   # ヒントモード全体制御
+│   ├── HintOverlayWindow.swift    # オーバーレイウィンドウ管理（動的ラベル追加対応）
+│   └── HintModeController.swift   # ヒントモード全体制御（プログレッシブレンダリング）
 ├── ScrollMode/
 │   ├── ScrollConfiguration.swift  # スクロールキー・設定定義
 │   ├── ScrollExecutor.swift       # スクロールイベント生成・実行
@@ -132,7 +132,7 @@ HintModeController
 - [x] ホットキーでヒントモード起動（#104, #107）
 - [x] `NativeAppCrawler`で操作可能要素取得（#104）
 - [x] `kAXPositionAttribute`/`kAXSizeAttribute`で位置取得（#104）
-- [x] A-Z, AA-AZ式ラベル生成（#104）
+- [x] AA-ZZ式2文字ラベル生成（#104）
 - [x] オーバーレイウィンドウでラベル表示（#104）
 - [x] キー入力で要素選択・実行（#104）
 - [x] ESCで終了、Backspaceで入力クリア（#104）
@@ -164,11 +164,25 @@ HintModeController
 - [x] システム設定 > 外観 > Liquid Glass（Clear/Tinted）に自動同期
 - [x] ライト/ダークモード両対応（`.primary`色使用）
 
+### プログレッシブレンダリング（#148）
+- [x] `AsyncThrowingStream`による逐次要素発見
+- [x] `crawlElementsStream()`メソッドをElementCrawlerプロトコルに追加
+- [x] インデックスベースのラベル生成（`generateLabel(at:)`）
+- [x] `HintOverlayWindow.addHint()`/`addHints()`で動的ラベル追加
+- [x] `Task.isCancelled`チェックによるESCキーでの走査中断
+- [x] 走査中も即座にキー入力で選択・実行可能
+
+**アーキテクチャ**:
+```
+[走査開始] → [要素発見] → [即座にyield] → [ラベル生成] → [UI追加] → [次の要素...]
+```
+
 ## パフォーマンス目標
 
 | 指標 | 目標 |
 |------|------|
 | ホットキー→表示 | <10ms |
+| 最初のヒントラベル表示 | <50ms |
 | メモリ | <30MB |
 | CPU（アイドル時） | 0% |
 

--- a/Portal/HintMode/HintLabelGenerator.swift
+++ b/Portal/HintMode/HintLabelGenerator.swift
@@ -17,35 +17,47 @@ enum HintLabelGenerator {
     /// Note: "F" is excluded because it's reserved for hint mode activation.
     private static let alphabet = Array("ABCDEGHIJKLMNOPQRSTUVWXYZ")
 
+    /// Generates a label for a given index.
+    ///
+    /// This method is designed for progressive/streaming label generation where
+    /// the total count is not known in advance. Labels are always two characters
+    /// starting from AA, AB, AC, ... to avoid prefix conflicts.
+    ///
+    /// - Parameter index: The zero-based index of the label to generate.
+    /// - Returns: The two-character label string for the given index.
+    static func generateLabel(at index: Int) -> String {
+        guard index >= 0 else { return "" }
+
+        let alphabetCount = alphabet.count
+
+        let first = index / alphabetCount
+        let second = index % alphabetCount
+
+        // Ensure we don't exceed available two-char combinations
+        guard first < alphabetCount else {
+            // Fallback for very large indices (unlikely in practice)
+            return "Z\(index)"
+        }
+
+        return String(alphabet[first]) + String(alphabet[second])
+    }
+
     /// Generates an array of hint labels for the given count.
     ///
     /// - Parameter count: The number of labels to generate.
     /// - Returns: An array of label strings.
     ///
-    /// Label generation strategy:
-    /// - 1-N items (N = alphabet size): Single characters (A, B, C, ...)
-    /// - N+1 and above: ALL two-character labels (AA, AB, AC, ...)
-    ///
-    /// This avoids overlap between single and two-character labels,
-    /// so "A" doesn't conflict with "AA" when selecting.
+    /// All labels are two characters (AA, AB, AC, ...) to avoid prefix conflicts.
     static func generateLabels(count: Int) -> [String] {
         guard count > 0 else { return [] }
 
-        let alphabetCount = alphabet.count
         var labels: [String] = []
 
-        if count <= alphabetCount {
-            // Use single character labels only
-            for i in 0..<count {
-                labels.append(String(alphabet[i]))
-            }
-        } else {
-            // Use ALL two-character labels (no single-char to avoid overlap)
-            outer: for first in alphabet {
-                for second in alphabet {
-                    if labels.count >= count { break outer }
-                    labels.append(String(first) + String(second))
-                }
+        // Always use two-character labels
+        outer: for first in alphabet {
+            for second in alphabet {
+                if labels.count >= count { break outer }
+                labels.append(String(first) + String(second))
             }
         }
 

--- a/Portal/Protocols/ElementCrawler.swift
+++ b/Portal/Protocols/ElementCrawler.swift
@@ -31,6 +31,16 @@ protocol ElementCrawler {
     /// - Throws: An error if crawling fails (e.g., accessibility not granted).
     func crawlElements(_ app: NSRunningApplication) async throws -> [HintTarget]
 
+    /// Crawls UI elements from the specified application as an async stream.
+    ///
+    /// This method yields elements as they are discovered, enabling progressive
+    /// rendering of hint labels. Use this for better responsiveness when crawling
+    /// applications with many UI elements.
+    ///
+    /// - Parameter app: The application to crawl elements from.
+    /// - Returns: An async stream of discovered hint targets.
+    func crawlElementsStream(_ app: NSRunningApplication) -> AsyncThrowingStream<HintTarget, Error>
+
     /// Determines whether this crawler can handle the specified application.
     ///
     /// - Parameter app: The application to check.

--- a/PortalTests/HintLabelGeneratorTests.swift
+++ b/PortalTests/HintLabelGeneratorTests.swift
@@ -27,27 +27,28 @@ struct HintLabelGeneratorTests {
     }
 
     @Test
-    func testGenerateLabelsSingleCharacter() {
+    func testGenerateLabelsSmallCount() {
+        // All labels are always two-character
         let labels = HintLabelGenerator.generateLabels(count: 5)
-        #expect(labels == ["A", "B", "C", "D", "E"])
+        #expect(labels == ["AA", "AB", "AC", "AD", "AE"])
     }
 
     @Test
-    func testGenerateLabelsFullAlphabet() {
-        // Note: "F" is excluded from the alphabet, so we have 25 single-character labels
+    func testGenerateLabelsFullAlphabetRow() {
+        // 25 labels (one row of two-char labels, F excluded from alphabet)
         let labels = HintLabelGenerator.generateLabels(count: 25)
         #expect(labels.count == 25)
-        #expect(labels.first == "A")
-        #expect(labels.last == "Z")
-        #expect(!labels.contains("F"))  // F should not be in the labels
+        #expect(labels.first == "AA")
+        #expect(labels.last == "AZ")
+        #expect(!labels.contains("AF"))  // F should not be in the labels
     }
 
     @Test
     func testGenerateLabelsTwoCharacters() {
-        // When count > 25, ALL labels are two-character (no overlap with single-char)
+        // All labels are two-character
         let labels = HintLabelGenerator.generateLabels(count: 28)
         #expect(labels.count == 28)
-        #expect(labels[0] == "AA")  // Starts with two-char
+        #expect(labels[0] == "AA")
         #expect(labels[1] == "AB")
         #expect(labels[24] == "AZ")  // 25 labels from AA to AZ (no AF)
         #expect(labels[25] == "BA")
@@ -59,12 +60,59 @@ struct HintLabelGeneratorTests {
     func testGenerateLabelsLargeCount() {
         let labels = HintLabelGenerator.generateLabels(count: 100)
         #expect(labels.count == 100)
-        // When count > 25, ALL labels are two-character
         #expect(labels[0] == "AA")
         #expect(labels[24] == "AZ")  // 25 two-char labels starting with A (no AF)
         #expect(labels[25] == "BA")
         #expect(labels[49] == "BZ")  // 25 two-char labels starting with B (no BF)
         #expect(labels[50] == "CA")
+    }
+
+    // MARK: - Index-based Label Generation Tests (for progressive rendering)
+
+    @Test
+    func testGenerateLabelAtIndexNegative() {
+        let label = HintLabelGenerator.generateLabel(at: -1)
+        #expect(label == "")
+    }
+
+    @Test
+    func testGenerateLabelAtIndexFirstRow() {
+        // All labels are two-character, starting from AA
+        // Alphabet has 25 chars (F excluded): A, B, C, D, E, G, H, ..., Z
+        #expect(HintLabelGenerator.generateLabel(at: 0) == "AA")
+        #expect(HintLabelGenerator.generateLabel(at: 1) == "AB")
+        #expect(HintLabelGenerator.generateLabel(at: 4) == "AE")
+        #expect(HintLabelGenerator.generateLabel(at: 5) == "AG")  // F is excluded
+        #expect(HintLabelGenerator.generateLabel(at: 24) == "AZ") // Last of first row
+    }
+
+    @Test
+    func testGenerateLabelAtIndexSecondRow() {
+        // Second row starts at index 25 (BA, BB, BC, ...)
+        #expect(HintLabelGenerator.generateLabel(at: 25) == "BA")
+        #expect(HintLabelGenerator.generateLabel(at: 26) == "BB")
+        #expect(HintLabelGenerator.generateLabel(at: 49) == "BZ")  // Last of second row
+        #expect(HintLabelGenerator.generateLabel(at: 50) == "CA")  // Start of third row
+        #expect(HintLabelGenerator.generateLabel(at: 74) == "CZ")  // Last of third row
+        #expect(HintLabelGenerator.generateLabel(at: 75) == "DA")  // Start of fourth row
+    }
+
+    @Test
+    func testGenerateLabelAtIndexSequence() {
+        // Test that progressive generation produces expected sequence
+        var labels: [String] = []
+        for i in 0..<30 {
+            labels.append(HintLabelGenerator.generateLabel(at: i))
+        }
+        // All labels should be two-char starting from AA
+        #expect(labels[0] == "AA")
+        #expect(labels[1] == "AB")
+        #expect(labels[24] == "AZ")
+        #expect(labels[25] == "BA")
+        #expect(labels[26] == "BB")
+        #expect(labels[27] == "BC")
+        #expect(labels[28] == "BD")
+        #expect(labels[29] == "BE")
     }
 
     // MARK: - Filter Tests


### PR DESCRIPTION
## Summary
- ヒントラベルをプログレッシブレンダリングで逐次表示するように変更
- AsyncThrowingStreamを使用して要素発見時に即座にUIを更新
- ヒントラベルを2文字（AA, AB, AC...）から開始するように変更

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `ElementCrawler.swift` | `crawlElementsStream()` メソッドをプロトコルに追加 |
| `NativeAppCrawler.swift` | AsyncThrowingStream対応、async化、`Task.yield()`による逐次更新 |
| `ElectronCrawler.swift` | AsyncThrowingStream対応、async化、`Task.yield()`による逐次更新 |
| `HintLabelGenerator.swift` | `generateLabel(at:)` インデックスベースラベル生成、2文字ラベル開始 |
| `HintOverlayWindow.swift` | `addHint()`/`addHints()`/`createEmptyForAllScreens()` 追加 |
| `HintModeController.swift` | プログレッシブレンダリングロジック実装 |
| `CLAUDE.md` | ドキュメント更新 |

## Test plan
- [x] Fキーでヒントモード起動し、ラベルが逐次表示されることを確認
- [x] ESCキーで走査を中断できることを確認
- [x] 走査中でもキー入力で要素を選択・実行できることを確認
- [x] ラベルがAA, AB, AC...と2文字で始まることを確認
- [x] `xcodebuild test` が全件パスすることを確認

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)