### PR TITLE
#135 Fix hint mode immediate deactivation on F key press

### DIFF
--- a/Portal/App/AppDelegate.swift
+++ b/Portal/App/AppDelegate.swift
@@ -169,9 +169,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
     private func handleHintModeHotkeyPressed() {
-        // Toggle hint mode if already active
+        // Toggle hint mode if already active (with cooldown to prevent immediate toggle-off)
         guard !HintModeController.shared.isActive else {
-            HintModeController.shared.deactivate()
+            // Only allow toggle-off after cooldown period to prevent same key press
+            // from immediately deactivating hint mode
+            if HintModeController.shared.canToggleOff() {
+                HintModeController.shared.deactivate()
+            }
             return
         }
 


### PR DESCRIPTION
## Summary
- ヒントモード起動時に同じFキー押下で即座に非アクティブ化される問題を修正
- アクティベーション後0.3秒のクールダウン期間を追加
- クールダウン期間中はホットキーによるトグルオフを無視

## 根本原因
Fキーでヒントモードを起動した際、`HotkeyManager`のイベントコールバックが非同期で呼び出され、その時点で`isActive=true`になっているため`deactivate()`が呼ばれていた。

## 実装
- `HintModeController`に`activationTime`プロパティを追加
- `canToggleOff()`メソッドでクールダウン期間（0.3秒）をチェック
- `AppDelegate.handleHintModeHotkeyPressed()`で`canToggleOff()`を確認してからトグルオフ

## Review scope
このPRでレビューしてほしいこと:
- クールダウン期間の値（0.3秒）が適切か
- ESCキーによる非アクティブ化に影響がないか

## Test plan
- [ ] Fキーでヒントモードを起動し、ヒントが表示されることを確認
- [ ] 0.3秒以上待ってからFキーを押すと非アクティブ化されることを確認
- [ ] ESCキーで即座に非アクティブ化できることを確認
- [ ] すべてのユニットテストがパス

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)